### PR TITLE
webCryptoAPI ERR_MODULE_NOT_FOUND error fix

### DIFF
--- a/src/lib/webCryptoAPI.ts
+++ b/src/lib/webCryptoAPI.ts
@@ -1,4 +1,4 @@
-import { neverGuard } from './misc-util';
+import { neverGuard } from './misc-util.js';
 
 function bufferToB64(buffer: ArrayBuffer): string {
   let binary = '';


### PR DESCRIPTION
## Summary
Added file extension to misc-util import to resolve ERR_MODULE_NOT_FOUND error.

## Additional Information