### PR TITLE
v1.0.12: fix(): multi-connection lock blocks reconnect

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gateio-api",
-  "version": "1.0.11",
+  "version": "1.0.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "gateio-api",
-      "version": "1.0.11",
+      "version": "1.0.12",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.6.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gateio-api",
-  "version": "1.0.11",
+  "version": "1.0.12",
   "description": "Complete & robust Node.js SDK for Gate.io's REST APIs, WebSockets & WebSocket APIs, with TypeScript declarations.",
   "scripts": {
     "clean": "rm -rf dist/*",

--- a/src/lib/BaseWSClient.ts
+++ b/src/lib/BaseWSClient.ts
@@ -370,7 +370,9 @@ export abstract class BaseWebsocketClient<
         return { wsKey };
       }
 
-      if (this.wsStore.isConnectionAttemptInProgress(wsKey)) {
+      if (
+        this.wsStore.isConnectionState(wsKey, WsConnectionStateEnum.CONNECTING)
+      ) {
         this.logger.error(
           'Refused to connect to ws, connection attempt already active',
           { ...WS_LOGGER_CATEGORY, wsKey },
@@ -468,6 +470,7 @@ export abstract class BaseWebsocketClient<
 
   private reconnectWithDelay(wsKey: TWSKey, connectionDelayMs: number) {
     this.clearTimers(wsKey);
+
     if (!this.wsStore.isConnectionAttemptInProgress(wsKey)) {
       this.setWsState(wsKey, WsConnectionStateEnum.RECONNECTING);
     }

--- a/src/lib/websocket/WsStore.types.ts
+++ b/src/lib/websocket/WsStore.types.ts
@@ -6,6 +6,7 @@ export enum WsConnectionStateEnum {
   CONNECTED = 2,
   CLOSING = 3,
   RECONNECTING = 4,
+  // ERROR_RECONNECTING = 5,
   // ERROR = 5,
 }
 


### PR DESCRIPTION
## Summary
<!-- Add a brief description of the pr: -->
- There's a lock in place to prevent duplicate connections. 
- Recent updates caused the lock to prevent reconnection attempts when a websocket drops. This fixes that block.

## Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
