### PR TITLE
feat(v1.1.0): allow pass-through headers for endpoints that support it

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2172,9 +2172,9 @@
       "dev": true
     },
     "node_modules/cross-spawn": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
       "dev": true,
       "dependencies": {
         "path-key": "^3.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gateio-api",
-  "version": "1.0.22",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "gateio-api",
-      "version": "1.0.22",
+      "version": "1.1.0",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.6.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gateio-api",
-  "version": "1.0.22",
+  "version": "1.1.0",
   "description": "Complete & robust Node.js SDK for Gate.io's REST APIs, WebSockets & WebSocket APIs, with TypeScript declarations.",
   "scripts": {
     "clean": "rm -rf dist/*",

--- a/src/RestClient.ts
+++ b/src/RestClient.ts
@@ -373,7 +373,7 @@ export class RestClient extends BaseRestClient {
     console.log(result);
 
     console.log(
-      `Your approximate latency to exchange server: 
+      `Your approximate latency to exchange server:
       One way: ${estimatedOneWayLatency}ms.
       Round trip: ${roundTripTime}ms.
       `,
@@ -2473,9 +2473,16 @@ export class RestClient extends BaseRestClient {
    * @returns Promise<FuturesOrder>
    */
   updateFuturesOrder(params: UpdateFuturesOrderReq): Promise<FuturesOrder> {
-    const { settle, order_id, ...body } = params;
+    const { settle, order_id, ...rest } = params;
+    const { ['x-gate-exptime']: xGateExptime, ...body } = rest;
+
+    const headers = xGateExptime
+      ? { 'x-gate-exptime': xGateExptime }
+      : undefined;
+
     return this.putPrivate(`/futures/${settle}/orders/${order_id}`, {
       body: body,
+      headers: headers,
     });
   }
 

--- a/src/types/request/futures.ts
+++ b/src/types/request/futures.ts
@@ -140,6 +140,7 @@ export interface GetFuturesOrdersByTimeRangeReq {
 }
 
 export interface UpdateFuturesOrderReq {
+  'x-gate-exptime'?: number;
   settle: 'btc' | 'usdt' | 'usd';
   order_id: string;
   size?: number;


### PR DESCRIPTION
## Summary
<!-- Add a brief description of the pr: -->
Some endpoints support parameters being sent as headers. Amend futures order is one example, where one parameter can be sent as a header. The implementation of the endpoint will automatically handle sending that parameter correctly, if provided.

## Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
