### PR TITLE
feat(v1.1.4): deprecated functions, added new response/request fields

### DIFF
--- a/.github/workflows/e2etest.yml
+++ b/.github/workflows/e2etest.yml
@@ -1,16 +1,12 @@
-name: 'Build & Test'
+name: E2ETests  
 
-on: [push]
-
-# on:
-#   # pull_request:
-#   #   branches:
-#   #     - "master"
-#   push:
-#     branches:
+on:
+  push:
+  pull_request:  
+  workflow_dispatch:  
 
 jobs:
-  build:
+  E2ETests:  
     name: 'Build & Test'
     runs-on: ubuntu-latest
 
@@ -33,8 +29,11 @@ jobs:
       - name: Check Build
         run: npm run build
 
-      - name: Test
-        run: npm run test
+      - name: Test Public API Calls
+        run: npm run test -- public.test.ts
+
+      - name: Test Private API Calls
+        run: npm run test -- private.test.ts
         env:
           API_KEY: ${{ secrets.API_KEY }}
           API_SECRET: ${{ secrets.API_SECRET }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gateio-api",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "gateio-api",
-      "version": "1.1.3",
+      "version": "1.1.4",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.6.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gateio-api",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "description": "Complete & robust Node.js SDK for Gate.io's REST APIs, WebSockets & WebSocket APIs, with TypeScript declarations.",
   "scripts": {
     "clean": "rm -rf dist/*",

--- a/src/RestClient.ts
+++ b/src/RestClient.ts
@@ -1741,6 +1741,7 @@ export class RestClient extends BaseRestClient {
   }
 
   /**
+   * @deprecated  as of 2025-02-10
    * Currencies supported by cross margin
    *
    * @returns Promise<GetCrossMarginCurrenciesResp[]>
@@ -1750,6 +1751,7 @@ export class RestClient extends BaseRestClient {
   }
 
   /**
+   * @deprecated  as of 2025-02-10
    * Retrieve detail of one single currency supported by cross margin
    *
    * @param params Parameters containing the currency name
@@ -1762,6 +1764,7 @@ export class RestClient extends BaseRestClient {
   }
 
   /**
+   * @deprecated  as of 2025-02-10
    * Retrieve cross margin account
    *
    * @returns Promise<GetCrossMarginAccountResp>
@@ -1771,6 +1774,7 @@ export class RestClient extends BaseRestClient {
   }
 
   /**
+   * @deprecated  as of 2025-02-10
    * Retrieve cross margin account change history
    *
    * Record time range cannot exceed 30 days.
@@ -1785,12 +1789,15 @@ export class RestClient extends BaseRestClient {
   }
 
   /**
+   *
+   * @deprecated  as of 2025-02-10
    * Create a cross margin borrow loan
    *
    * Borrow amount cannot be less than currency minimum borrow amount.
    *
    * @param params Parameters for creating a cross margin borrow loan
    * @returns Promise<SubmitCrossMarginBorrowLoanResp>
+   *
    */
   submitCrossMarginBorrowLoan(
     params: SubmitCrossMarginBorrowLoanReq,
@@ -1799,6 +1806,7 @@ export class RestClient extends BaseRestClient {
   }
 
   /**
+   *
    * List cross margin borrow history
    *
    * Sort by creation time in descending order by default. Set reverse=false to return ascending results.
@@ -1813,6 +1821,7 @@ export class RestClient extends BaseRestClient {
   }
 
   /**
+   * @deprecated  as of 2025-02-10
    * Retrieve single borrow loan detail
    *
    * @param params Parameters containing the borrow loan ID
@@ -1824,6 +1833,7 @@ export class RestClient extends BaseRestClient {
     return this.getPrivate(`/margin/cross/loans/${params.loan_id}`);
   }
   /**
+   * @deprecated  as of 2025-02-10
    * Cross margin repayments
    *
    * When the liquidity of the currency is insufficient and the transaction risk is high, the currency will be disabled, and funds cannot be transferred. When the available balance of cross-margin is insufficient, the balance of the spot account can be used for repayment. Please ensure that the balance of the spot account is sufficient, and system uses cross-margin account for repayment first.
@@ -1839,6 +1849,7 @@ export class RestClient extends BaseRestClient {
   }
 
   /**
+   * @deprecated  as of 2025-02-10
    * Retrieve cross margin repayments
    *
    * Sort by creation time in descending order by default. Set reverse=false to return ascending results.
@@ -1853,6 +1864,7 @@ export class RestClient extends BaseRestClient {
   }
 
   /**
+   * @deprecated  as of 2025-02-10
    * Interest records for the cross margin account
    *
    * @param params Parameters for retrieving interest records
@@ -1865,6 +1877,7 @@ export class RestClient extends BaseRestClient {
   }
 
   /**
+   * @deprecated  as of 2025-02-10
    * Get the max transferable amount for a specific cross margin currency
    *
    * @param params Parameters for retrieving the max transferable amount
@@ -1881,6 +1894,7 @@ export class RestClient extends BaseRestClient {
   }
 
   /**
+   * @deprecated  as of 2025-02-10
    * Estimated interest rates
    *
    * Please note that the interest rates are subject to change based on the borrowing and lending demand, and therefore, the provided rates may not be entirely accurate.
@@ -1893,6 +1907,7 @@ export class RestClient extends BaseRestClient {
   }
 
   /**
+   * @deprecated  as of 2025-02-10
    * Get the max borrowable amount for a specific cross margin currency
    *
    * @param params Parameters for retrieving the max borrowable amount
@@ -4342,5 +4357,23 @@ export class RestClient extends BaseRestClient {
    */
   getUserRebateInfo(): Promise<{ invite_uid: number }> {
     return this.getPrivate('/rebate/user/info');
+  }
+
+  /**
+   * Query user-subordinate relationship
+   *
+   * Checks whether specified users are in the system and their relationship status
+   */
+  getUserSubordinateRelationships(params: {
+    user_id_list: string; // Comma-separated list of user IDs (max 100)
+  }): Promise<{
+    list: {
+      uid: number;
+      belong: string;
+      type: number;
+      ref_uid: number;
+    }[];
+  }> {
+    return this.getPrivate('/rebate/user/sub_relation', params);
   }
 }

--- a/src/types/request/wallet.ts
+++ b/src/types/request/wallet.ts
@@ -42,6 +42,7 @@ export interface ListPushOrdersReq {
   to?: number;
   limit?: number;
   offset?: number;
+  transaction_type?: string;
 }
 
 export interface SubmitSubToSubTransferReq {

--- a/src/types/response/futures.ts
+++ b/src/types/response/futures.ts
@@ -93,6 +93,7 @@ export interface LiquidationHistoryRecord {
   time: number;
   contract: string;
   size: number;
+  order_size: number;
   order_price: string;
   fill_price: string;
   left: number;


### PR DESCRIPTION
Changelog based on Gateio API documentation:


v4.91.0

2025-02-10

GET /margin/cross/borrowable endpoint, deprecated
GET /margin/cross/estimate_rate endpoint, deprecated
GET /margin/cross/transferable endpoint, deprecated
GET /margin/cross/interest_records endpoint, deprecated
GET /margin/cross/repayments endpoint, deprecated
POST /margin/cross/repayments endpoint, deprecated
GET /margin/cross/loans/{loan_id} endpoint, deprecated
POST /margin/cross/loans endpoint, deprecated
GET /margin/cross/account_book endpoint, deprecated
GET /margin/cross/accounts endpoint, deprecated
GET /margin/cross/currencies/{currency} endpoint, deprecated
GET /margin/cross/currencies endpoint, deprecated
v4.90.0

2025-01-20

Add transaction_type field in GET /wallet/push query
New feature GET /rebate/user/sub_relation endpoint, Query whether the specified user is in the system
Add order_size field inGET /futures/{settle}/liq_orders response
Add type field in GET /spot/currency_pairs response