### PR TITLE
fix: correct testnet WebSocket URL for perpFuturesUSDTV4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4419,22 +4419,6 @@
         "node": ">= 0.8.0"
       }
     },
-    "node_modules/prettier": {
-      "version": "3.2.5",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.2.5.tgz",
-      "integrity": "sha512-3/GWa9aOC0YeD7LUfvOG2NiDyhOWRvt1k+rcKhOuYnMY24iiCphgneUfJDyFXd6rZCAnuLBv6UeAULtrhT/F4A==",
-      "dev": true,
-      "peer": true,
-      "bin": {
-        "prettier": "bin/prettier.cjs"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/prettier/prettier?sponsor=1"
-      }
-    },
     "node_modules/prettier-linter-helpers": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/prettier-linter-helpers/-/prettier-linter-helpers-1.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gateio-api",
-  "version": "1.2.8",
+  "version": "1.2.9",
   "description": "Complete & Robust Node.js SDK for Gate.com's REST APIs, WebSockets & WebSocket APIs, with TypeScript declarations.",
   "scripts": {
     "clean": "rm -rf dist/*",

--- a/src/lib/websocket/websocket-util.ts
+++ b/src/lib/websocket/websocket-util.ts
@@ -105,7 +105,7 @@ export const WS_BASE_URL_MAP: Record<
   },
   perpFuturesUSDTV4: {
     livenet: 'wss://fx-ws.gateio.ws/v4/ws/usdt',
-    testnet: 'wss://fx-ws-testnet.gateio.ws/v4/ws/usdt',
+    testnet: 'wss://ws-testnet.gate.com/v4/ws/futures/usdt',
   },
   perpFuturesBTCV4: {
     livenet: 'wss://fx-ws.gateio.ws/v4/ws/btc',


### PR DESCRIPTION
The testnet WebSocket URL for `perpFuturesUSDTV4` was incorrect in `WS_BASE_URL_MAP`.

`wss://fx-ws-testnet.gateio.ws/v4/ws/usdt` -> `wss://ws-testnet.gate.com/v4/ws/futures/usdt`

https://www.gate.com/docs/developers/futures/ws/en/#server-url

Fixes #76