### PR TITLE
feat(v1.3.2): update version to 1.3.2, add new futures price-triggered order update endpoint

### DIFF
--- a/docs/endpointFunctionList.md
+++ b/docs/endpointFunctionList.md
@@ -49,299 +49,302 @@ This table includes all endpoints from the official Exchange API docs and corres
 
 | Function | AUTH | HTTP Method | Endpoint |
 | -------- | :------: | :------: | -------- |
-| [getSystemMaintenanceStatus()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L418) |  | GET | `/v1/public/system_info` |
-| [submitWithdrawal()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L435) | :closed_lock_with_key:  | POST | `/withdrawals` |
-| [submitSpotMainAccountTransfer()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L449) | :closed_lock_with_key:  | POST | `/withdrawals/push` |
-| [cancelWithdrawal()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L465) | :closed_lock_with_key:  | DELETE | `/withdrawals/{withdrawal_id}` |
-| [getCurrencyChains()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L482) |  | GET | `/wallet/currency_chains` |
-| [createDepositAddress()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L492) | :closed_lock_with_key:  | GET | `/wallet/deposit_address` |
-| [getWithdrawalRecords()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L506) | :closed_lock_with_key:  | GET | `/wallet/withdrawals` |
-| [getDepositRecords()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L520) | :closed_lock_with_key:  | GET | `/wallet/deposits` |
-| [submitTransfer()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L539) | :closed_lock_with_key:  | POST | `/wallet/transfers` |
-| [submitMainSubTransfer()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L551) | :closed_lock_with_key:  | POST | `/wallet/sub_account_transfers` |
-| [getMainSubTransfers()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L565) | :closed_lock_with_key:  | GET | `/wallet/sub_account_transfers` |
-| [submitSubToSubTransfer()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L579) | :closed_lock_with_key:  | POST | `/wallet/sub_account_to_sub_account` |
-| [getTransferStatus()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L594) | :closed_lock_with_key:  | GET | `/wallet/order_status` |
-| [getWithdrawalStatus()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L610) | :closed_lock_with_key:  | GET | `/wallet/withdraw_status` |
-| [getSubBalance()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L625) | :closed_lock_with_key:  | GET | `/wallet/sub_account_balances` |
-| [getSubMarginBalances()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L640) | :closed_lock_with_key:  | GET | `/wallet/sub_account_margin_balances` |
-| [getSubFuturesBalances()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L652) | :closed_lock_with_key:  | GET | `/wallet/sub_account_futures_balances` |
-| [getSubCrossMarginBalances()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L665) | :closed_lock_with_key:  | GET | `/wallet/sub_account_cross_margin_balances` |
-| [getSavedAddresses()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L677) | :closed_lock_with_key:  | GET | `/wallet/saved_address` |
-| [getTradingFees()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L687) | :closed_lock_with_key:  | GET | `/wallet/fee` |
-| [getBalances()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L708) | :closed_lock_with_key:  | GET | `/wallet/total_balance` |
-| [getSmallBalances()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L717) | :closed_lock_with_key:  | GET | `/wallet/small_balance` |
-| [convertSmallBalance()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L727) | :closed_lock_with_key:  | POST | `/wallet/small_balance` |
-| [getSmallBalanceHistory()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L740) | :closed_lock_with_key:  | GET | `/wallet/small_balance_history` |
-| [getPushOrders()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L752) | :closed_lock_with_key:  | GET | `/wallet/push` |
-| [createSubAccount()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L767) | :closed_lock_with_key:  | POST | `/sub_accounts` |
-| [getSubAccounts()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L778) | :closed_lock_with_key:  | GET | `/sub_accounts` |
-| [getSubAccount()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L788) | :closed_lock_with_key:  | GET | `/sub_accounts/{user_id}` |
-| [createSubAccountApiKey()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L798) | :closed_lock_with_key:  | POST | `/sub_accounts/{user_id}/keys` |
-| [getSubAccountApiKeys()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L811) | :closed_lock_with_key:  | GET | `/sub_accounts/{user_id}/keys` |
-| [updateSubAccountApiKey()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L823) | :closed_lock_with_key:  | PUT | `/sub_accounts/{user_id}/keys/{key}` |
-| [deleteSubAccountApiKey()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L834) | :closed_lock_with_key:  | DELETE | `/sub_accounts/{user_id}/keys/{key}` |
-| [getSubAccountApiKey()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L849) | :closed_lock_with_key:  | GET | `/sub_accounts/{user_id}/keys/{key}` |
-| [lockSubAccount()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L864) | :closed_lock_with_key:  | POST | `/sub_accounts/{user_id}/lock` |
-| [unlockSubAccount()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L874) | :closed_lock_with_key:  | POST | `/sub_accounts/{user_id}/unlock` |
-| [getSubAccountMode()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L888) | :closed_lock_with_key:  | GET | `/sub_accounts/unified_mode` |
-| [getUnifiedAccountInfo()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L905) | :closed_lock_with_key:  | GET | `/unified/accounts` |
-| [getUnifiedMaxBorrow()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L921) | :closed_lock_with_key:  | GET | `/unified/borrowable` |
-| [getUnifiedMaxTransferable()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L937) | :closed_lock_with_key:  | GET | `/unified/transferable` |
-| [getUnifiedMaxTransferables()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L952) | :closed_lock_with_key:  | GET | `/unified/transferables` |
-| [submitUnifiedBorrowOrRepay()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L973) | :closed_lock_with_key:  | POST | `/unified/loans` |
-| [getUnifiedLoans()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L985) | :closed_lock_with_key:  | GET | `/unified/loans` |
-| [getUnifiedLoanRecords()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L995) | :closed_lock_with_key:  | GET | `/unified/loan_records` |
-| [getUnifiedInterestRecords()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L1007) | :closed_lock_with_key:  | GET | `/unified/interest_records` |
-| [getUnifiedRiskUnitDetails()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L1018) | :closed_lock_with_key:  | GET | `/unified/risk_units` |
-| [setUnifiedAccountMode()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L1030) | :closed_lock_with_key:  | PUT | `/unified/unified_mode` |
-| [getUnifiedAccountMode()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L1039) | :closed_lock_with_key:  | GET | `/unified/unified_mode` |
-| [getUnifiedEstimateRate()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L1051) | :closed_lock_with_key:  | GET | `/unified/estimate_rate` |
-| [getUnifiedCurrencyDiscountTiers()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L1062) |  | GET | `/unified/currency_discount_tiers` |
-| [getLoanMarginTiers()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L1074) |  | GET | `/unified/loan_margin_tiers` |
-| [portfolioMarginCalculate()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L1091) |  | POST | `/unified/portfolio_calculator` |
-| [getUserCurrencyLeverageConfig()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L1105) | :closed_lock_with_key:  | GET | `/unified/leverage/user_currency_config` |
-| [getUserCurrencyLeverageSettings()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L1119) | :closed_lock_with_key:  | GET | `/unified/leverage/user_currency_setting` |
-| [updateUserCurrencyLeverage()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L1134) | :closed_lock_with_key:  | POST | `/unified/leverage/user_currency_setting` |
-| [getUnifiedLoanCurrencies()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L1149) | :closed_lock_with_key:  | GET | `/unified/currencies` |
-| [getHistoricalLendingRates()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L1161) | :closed_lock_with_key:  | GET | `/unified/history_loan_rate` |
-| [submitUnifiedLoanRepay()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L1167) | :closed_lock_with_key:  | POST | `/unified/loans/repay` |
-| [getSpotCurrencies()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L1187) |  | GET | `/spot/currencies` |
-| [getSpotCurrency()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L1197) |  | GET | `/spot/currencies/{currency}` |
-| [getSpotCurrencyPairs()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L1206) |  | GET | `/spot/currency_pairs` |
-| [getSpotCurrencyPair()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L1216) |  | GET | `/spot/currency_pairs/{currency_pair}` |
-| [getSpotTicker()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L1230) |  | GET | `/spot/tickers` |
-| [getSpotOrderBook()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L1245) |  | GET | `/spot/order_book` |
-| [getSpotTrades()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L1258) |  | GET | `/spot/trades` |
-| [getSpotCandles()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L1270) |  | GET | `/spot/candlesticks` |
-| [getSpotFeeRates()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L1282) | :closed_lock_with_key:  | GET | `/spot/fee` |
-| [getSpotBatchFeeRates()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L1291) | :closed_lock_with_key:  | GET | `/spot/batch_fee` |
-| [getSpotAccounts()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L1303) | :closed_lock_with_key:  | GET | `/spot/accounts` |
-| [getSpotAccountBook()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L1315) | :closed_lock_with_key:  | GET | `/spot/account_book` |
-| [submitSpotBatchOrders()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L1334) | :closed_lock_with_key:  | POST | `/spot/batch_orders` |
-| [getSpotOpenOrders()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L1361) | :closed_lock_with_key:  | GET | `/spot/open_orders` |
-| [submitSpotClosePosCrossDisabled()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L1377) | :closed_lock_with_key:  | POST | `/spot/cross_liquidate_orders` |
-| [submitSpotOrder()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L1393) | :closed_lock_with_key:  | POST | `/spot/orders` |
-| [getSpotOrders()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L1410) | :closed_lock_with_key:  | GET | `/spot/orders` |
-| [cancelSpotOpenOrders()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L1425) | :closed_lock_with_key:  | DELETE | `/spot/orders` |
-| [batchCancelSpotOrders()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L1453) | :closed_lock_with_key:  | POST | `/spot/cancel_batch_orders` |
-| [getSpotOrder()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L1478) | :closed_lock_with_key:  | GET | `/spot/orders/{order_id}` |
-| [updateSpotOrder()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L1495) | :closed_lock_with_key:  | PATCH | `/spot/orders/{order_id}` |
-| [cancelSpotOrder()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L1523) | :closed_lock_with_key:  | DELETE | `/spot/orders/{order_id}` |
-| [getSpotTradingHistory()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L1545) | :closed_lock_with_key:  | GET | `/spot/my_trades` |
-| [submitSpotCountdownOrders()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L1574) | :closed_lock_with_key:  | POST | `/spot/countdown_cancel_all` |
-| [batchUpdateSpotOrders()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L1593) | :closed_lock_with_key:  | POST | `/spot/amend_batch_orders` |
-| [getSpotInsuranceHistory()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L1620) | :closed_lock_with_key:  | GET | `/spot/insurance_history` |
-| [submitSpotPriceTriggerOrder()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L1634) | :closed_lock_with_key:  | POST | `/spot/price_orders` |
-| [getSpotAutoOrders()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L1646) | :closed_lock_with_key:  | GET | `/spot/price_orders` |
-| [cancelAllOpenSpotOrders()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L1658) | :closed_lock_with_key:  | DELETE | `/spot/price_orders` |
-| [getPriceTriggeredOrder()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L1671) | :closed_lock_with_key:  | GET | `/spot/price_orders/{order_id}` |
-| [cancelSpotTriggeredOrder()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L1683) | :closed_lock_with_key:  | DELETE | `/spot/price_orders/{order_id}` |
-| [setCollateralCurrency()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L1697) | :closed_lock_with_key:  | POST | `/unified/collateral_currencies` |
-| [getMarginAccounts()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L1718) | :closed_lock_with_key:  | GET | `/margin/accounts` |
-| [getMarginBalanceHistory()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L1732) | :closed_lock_with_key:  | GET | `/margin/account_book` |
-| [getFundingAccounts()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L1750) | :closed_lock_with_key:  | GET | `/margin/funding_accounts` |
-| [updateAutoRepaymentSetting()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L1768) | :closed_lock_with_key:  | POST | `/margin/auto_repay` |
-| [getAutoRepaymentSetting()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L1779) | :closed_lock_with_key:  | GET | `/margin/auto_repay` |
-| [getMarginTransferableAmount()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L1793) | :closed_lock_with_key:  | GET | `/margin/transferable` |
-| [getCrossMarginCurrencies()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L1810) |  | GET | `/margin/cross/currencies` |
-| [getCrossMarginCurrency()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L1821) |  | GET | `/margin/cross/currencies/{currency}` |
-| [getCrossMarginAccount()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L1833) | :closed_lock_with_key:  | GET | `/margin/cross/accounts` |
-| [getCrossMarginAccountHistory()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L1846) | :closed_lock_with_key:  | GET | `/margin/cross/account_book` |
-| [submitCrossMarginBorrowLoan()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L1863) | :closed_lock_with_key:  | POST | `/margin/cross/loans` |
-| [getCrossMarginBorrowHistory()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L1878) | :closed_lock_with_key:  | GET | `/margin/cross/loans` |
-| [getCrossMarginBorrowLoan()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L1891) | :closed_lock_with_key:  | GET | `/margin/cross/loans/{loan_id}` |
-| [submitCrossMarginRepayment()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L1906) | :closed_lock_with_key:  | POST | `/margin/cross/repayments` |
-| [getCrossMarginRepayments()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L1922) | :closed_lock_with_key:  | GET | `/margin/cross/repayments` |
-| [getCrossMarginInterestRecords()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L1935) | :closed_lock_with_key:  | GET | `/margin/cross/interest_records` |
-| [getCrossMarginTransferableAmount()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L1951) | :closed_lock_with_key:  | GET | `/margin/cross/transferable` |
-| [getEstimatedInterestRates()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L1967) | :closed_lock_with_key:  | GET | `/margin/cross/estimate_rate` |
-| [getCrossMarginBorrowableAmount()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L1981) | :closed_lock_with_key:  | GET | `/margin/cross/borrowable` |
-| [getMarginUserLoanTiers()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L1994) | :closed_lock_with_key:  | GET | `/margin/user/loan_margin_tiers` |
-| [getMarginPublicLoanTiers()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L2010) |  | GET | `/margin/loan_margin_tiers` |
-| [setMarginUserLeverage()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L2026) | :closed_lock_with_key:  | POST | `/margin/leverage/user_market_setting` |
-| [getMarginUserAccounts()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L2043) | :closed_lock_with_key:  | GET | `/margin/user/account` |
-| [getLendingMarkets()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L2058) |  | GET | `/margin/uni/currency_pairs` |
-| [getLendingMarket()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L2073) |  | GET | `/margin/uni/currency_pairs/{currency_pair}` |
-| [getEstimatedInterestRate()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L2085) | :closed_lock_with_key:  | GET | `/margin/uni/estimate_rate` |
-| [submitMarginUNIBorrowOrRepay()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L2095) | :closed_lock_with_key:  | POST | `/margin/uni/loans` |
-| [getMarginUNILoans()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L2111) | :closed_lock_with_key:  | GET | `/margin/uni/loans` |
-| [getMarginUNILoanRecords()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L2121) | :closed_lock_with_key:  | GET | `/margin/uni/loan_records` |
-| [getMarginUNIInterestRecords()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L2133) | :closed_lock_with_key:  | GET | `/margin/uni/interest_records` |
-| [getMarginUNIMaxBorrow()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L2145) | :closed_lock_with_key:  | GET | `/margin/uni/borrowable` |
-| [getFlashSwapCurrencyPairs()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L2161) |  | GET | `/flash_swap/currency_pairs` |
-| [submitFlashSwapOrder()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L2177) | :closed_lock_with_key:  | POST | `/flash_swap/orders` |
-| [getFlashSwapOrders()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L2189) | :closed_lock_with_key:  | GET | `/flash_swap/orders` |
-| [getFlashSwapOrder()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L2201) | :closed_lock_with_key:  | GET | `/flash_swap/orders/{order_id}` |
-| [submitFlashSwapOrderPreview()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L2211) | :closed_lock_with_key:  | POST | `/flash_swap/orders/preview` |
-| [getFuturesContracts()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L2228) |  | GET | `/futures/{settle}/contracts` |
-| [getFuturesContract()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L2243) |  | GET | `/futures/{settle}/contracts/{contract}` |
-| [getFuturesOrderBook()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L2258) |  | GET | `/futures/{settle}/order_book` |
-| [getFuturesTrades()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L2271) |  | GET | `/futures/{settle}/trades` |
-| [getFuturesCandles()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L2286) |  | GET | `/futures/{settle}/candlesticks` |
-| [getPremiumIndexKLines()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L2299) |  | GET | `/futures/{settle}/premium_index` |
-| [getFuturesTickers()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L2312) |  | GET | `/futures/{settle}/tickers` |
-| [getFundingRates()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L2329) |  | GET | `/futures/{settle}/funding_rate` |
-| [getFuturesInsuranceBalanceHistory()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L2348) |  | GET | `/futures/{settle}/insurance` |
-| [getFuturesStats()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L2367) |  | GET | `/futures/{settle}/contract_stats` |
-| [getIndexConstituents()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L2378) |  | GET | `/futures/{settle}/index_constituents/{index}` |
-| [getLiquidationHistory()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L2395) |  | GET | `/futures/{settle}/liq_orders` |
-| [getRiskLimitTiers()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L2412) |  | GET | `/futures/{settle}/risk_limit_tiers` |
-| [getFuturesAccount()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L2423) | :closed_lock_with_key:  | GET | `/futures/{settle}/accounts` |
-| [getFuturesAccountBook()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L2437) | :closed_lock_with_key:  | GET | `/futures/{settle}/account_book` |
-| [getFuturesPositions()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L2450) | :closed_lock_with_key:  | GET | `/futures/{settle}/positions` |
-| [getFuturesPosition()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L2463) | :closed_lock_with_key:  | GET | `/futures/{settle}/positions/{contract}` |
-| [updateFuturesMargin()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L2478) | :closed_lock_with_key:  | POST | `/futures/{settle}/positions/{contract}/margin` |
-| [updateFuturesLeverage()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L2495) | :closed_lock_with_key:  | POST | `/futures/{settle}/positions/{contract}/leverage` |
-| [updateFuturesPositionMode()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L2514) | :closed_lock_with_key:  | POST | `/futures/{settle}/positions/cross_mode` |
-| [updatePositionRiskLimit()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L2531) | :closed_lock_with_key:  | POST | `/futures/{settle}/positions/{contract}/risk_limit` |
-| [updateFuturesDualMode()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L2551) | :closed_lock_with_key:  | POST | `/futures/{settle}/dual_mode` |
-| [getDualModePosition()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L2567) | :closed_lock_with_key:  | GET | `/futures/{settle}/dual_comp/positions/{contract}` |
-| [updateDualModePositionMargin()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L2582) | :closed_lock_with_key:  | POST | `/futures/{settle}/dual_comp/positions/{contract}/margin` |
-| [updateDualModePositionLeverage()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L2598) | :closed_lock_with_key:  | POST | `/futures/{settle}/dual_comp/positions/{contract}/leverage` |
-| [updateDualModePositionRiskLimit()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L2614) | :closed_lock_with_key:  | POST | `/futures/{settle}/dual_comp/positions/{contract}/risk_limit` |
-| [submitFuturesOrder()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L2641) | :closed_lock_with_key:  | POST | `/futures/{settle}/orders` |
-| [getFuturesOrders()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L2662) | :closed_lock_with_key:  | GET | `/futures/{settle}/orders` |
-| [cancelAllFuturesOrders()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L2677) | :closed_lock_with_key:  | DELETE | `/futures/{settle}/orders` |
-| [getFuturesOrdersByTimeRange()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L2697) | :closed_lock_with_key:  | GET | `/futures/{settle}/orders_timerange` |
-| [submitFuturesBatchOrders()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L2720) | :closed_lock_with_key:  | POST | `/futures/{settle}/batch_orders` |
-| [getFuturesOrder()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L2745) | :closed_lock_with_key:  | GET | `/futures/{settle}/orders/{order_id}` |
-| [cancelFuturesOrder()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L2762) | :closed_lock_with_key:  | DELETE | `/futures/{settle}/orders/{order_id}` |
-| [updateFuturesOrder()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L2785) | :closed_lock_with_key:  | PUT | `/futures/{settle}/orders/{order_id}` |
-| [getFuturesTradingHistory()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L2806) | :closed_lock_with_key:  | GET | `/futures/{settle}/my_trades` |
-| [getFuturesTradingHistoryByTimeRange()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L2821) | :closed_lock_with_key:  | GET | `/futures/{settle}/my_trades_timerange` |
-| [getFuturesPositionHistory()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L2834) | :closed_lock_with_key:  | GET | `/futures/{settle}/position_close` |
-| [getFuturesLiquidationHistory()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L2847) | :closed_lock_with_key:  | GET | `/futures/{settle}/liquidates` |
-| [getFuturesAutoDeleveragingHistory()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L2860) | :closed_lock_with_key:  | GET | `/futures/{settle}/auto_deleverages` |
-| [setFuturesOrderCancelCountdown()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L2877) | :closed_lock_with_key:  | POST | `/futures/{settle}/countdown_cancel_all` |
-| [getFuturesUserTradingFees()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L2894) | :closed_lock_with_key:  | GET | `/futures/{settle}/fee` |
-| [batchCancelFuturesOrders()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L2912) | :closed_lock_with_key:  | POST | `/futures/{settle}/batch_cancel_orders` |
-| [batchUpdateFuturesOrders()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L2939) | :closed_lock_with_key:  | POST | `/futures/{settle}/batch_amend_orders` |
-| [getRiskLimitTable()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L2961) |  | GET | `/futures/{settle}/risk_limit_table` |
-| [submitFuturesPriceTriggeredOrder()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L2974) | :closed_lock_with_key:  | POST | `/futures/{settle}/price_orders` |
-| [getFuturesAutoOrders()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L2987) | :closed_lock_with_key:  | GET | `/futures/{settle}/price_orders` |
-| [cancelAllOpenFuturesOrders()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L3000) | :closed_lock_with_key:  | DELETE | `/futures/{settle}/price_orders` |
-| [getFuturesPriceTriggeredOrder()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L3016) | :closed_lock_with_key:  | GET | `/futures/{settle}/price_orders/{order_id}` |
-| [cancelFuturesPriceTriggeredOrder()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L3031) | :closed_lock_with_key:  | DELETE | `/futures/{settle}/price_orders/{order_id}` |
-| [getFuturesPositionCloseHistory()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L3040) | :closed_lock_with_key:  | GET | `/futures/{settle}/position_close_history` |
-| [getFuturesInsuranceHistory()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L3049) | :closed_lock_with_key:  | GET | `/futures/{settle}/insurance` |
-| [getAllDeliveryContracts()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L3066) |  | GET | `/delivery/{settle}/contracts` |
-| [getDeliveryContract()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L3078) |  | GET | `/delivery/{settle}/contracts/{contract}` |
-| [getDeliveryOrderBook()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L3093) |  | GET | `/delivery/{settle}/order_book` |
-| [getDeliveryTrades()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L3106) |  | GET | `/delivery/{settle}/trades` |
-| [getDeliveryCandles()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L3120) |  | GET | `/delivery/{settle}/candlesticks` |
-| [getDeliveryTickers()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L3131) |  | GET | `/delivery/{settle}/tickers` |
-| [getDeliveryInsuranceBalanceHistory()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L3148) |  | GET | `/delivery/{settle}/insurance` |
-| [getDeliveryAccount()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L3167) | :closed_lock_with_key:  | GET | `/delivery/{settle}/accounts` |
-| [getDeliveryBook()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L3178) | :closed_lock_with_key:  | GET | `/delivery/{settle}/account_book` |
-| [getDeliveryPositions()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L3189) | :closed_lock_with_key:  | GET | `/delivery/{settle}/positions` |
-| [getDeliveryPosition()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L3199) | :closed_lock_with_key:  | GET | `/delivery/{settle}/positions/{contract}` |
-| [updateDeliveryMargin()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L3214) | :closed_lock_with_key:  | POST | `/delivery/{settle}/positions/{contract}/margin` |
-| [updateDeliveryLeverage()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L3232) | :closed_lock_with_key:  | POST | `/delivery/{settle}/positions/{contract}/leverage` |
-| [updateDeliveryRiskLimit()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L3250) | :closed_lock_with_key:  | POST | `/delivery/{settle}/positions/{contract}/risk_limit` |
-| [submitDeliveryOrder()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L3270) | :closed_lock_with_key:  | POST | `/delivery/{settle}/orders` |
-| [getDeliveryOrders()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L3285) | :closed_lock_with_key:  | GET | `/delivery/{settle}/orders` |
-| [cancelAllDeliveryOrders()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L3298) | :closed_lock_with_key:  | DELETE | `/delivery/{settle}/orders` |
-| [getDeliveryOrder()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L3317) | :closed_lock_with_key:  | GET | `/delivery/{settle}/orders/{order_id}` |
-| [cancelDeliveryOrder()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L3332) | :closed_lock_with_key:  | DELETE | `/delivery/{settle}/orders/{order_id}` |
-| [getDeliveryTradingHistory()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L3347) | :closed_lock_with_key:  | GET | `/delivery/{settle}/my_trades` |
-| [getDeliveryClosedPositions()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L3360) | :closed_lock_with_key:  | GET | `/delivery/{settle}/position_close` |
-| [getDeliveryLiquidationHistory()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L3373) | :closed_lock_with_key:  | GET | `/delivery/{settle}/liquidates` |
-| [getDeliverySettlementHistory()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L3386) | :closed_lock_with_key:  | GET | `/delivery/{settle}/settlements` |
-| [submitDeliveryTriggeredOrder()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L3399) | :closed_lock_with_key:  | POST | `/delivery/{settle}/price_orders` |
-| [getDeliveryAutoOrders()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L3414) | :closed_lock_with_key:  | GET | `/delivery/{settle}/price_orders` |
-| [cancelAllOpenDeliveryOrders()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L3427) | :closed_lock_with_key:  | DELETE | `/delivery/{settle}/price_orders` |
-| [getDeliveryTriggeredOrder()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L3443) | :closed_lock_with_key:  | GET | `/delivery/{settle}/price_orders/{order_id}` |
-| [cancelTriggeredDeliveryOrder()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L3458) | :closed_lock_with_key:  | DELETE | `/delivery/{settle}/price_orders/{order_id}` |
-| [getOptionsUnderlyings()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L3477) |  | GET | `/options/underlyings` |
-| [getOptionsExpirationTimes()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L3487) |  | GET | `/options/expirations` |
-| [getOptionsContracts()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L3497) |  | GET | `/options/contracts` |
-| [getOptionsContract()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L3510) |  | GET | `/options/contracts/{contract}` |
-| [getOptionsSettlementHistory()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L3520) |  | GET | `/options/settlements` |
-| [getOptionsContractSettlement()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L3532) |  | GET | `/options/settlements/{contract}` |
-| [getOptionsMySettlements()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L3547) | :closed_lock_with_key:  | GET | `/options/my_settlements` |
-| [getOptionsOrderBook()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L3561) |  | GET | `/options/order_book` |
-| [getOptionsTickers()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L3573) |  | GET | `/options/tickers` |
-| [getOptionsUnderlyingTicker()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L3587) |  | GET | `/options/underlying/tickers/{underlying}` |
-| [getOptionsCandles()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L3601) |  | GET | `/options/candlesticks` |
-| [getOptionsUnderlyingCandles()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L3611) |  | GET | `/options/underlying/candlesticks` |
-| [getOptionsTrades()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L3623) |  | GET | `/options/trades` |
-| [getOptionsAccount()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L3632) | :closed_lock_with_key:  | GET | `/options/accounts` |
-| [getOptionsAccountChange()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L3642) | :closed_lock_with_key:  | GET | `/options/account_book` |
-| [getOptionsPositionsUnderlying()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L3654) | :closed_lock_with_key:  | GET | `/options/positions` |
-| [getOptionsPositionContract()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L3666) | :closed_lock_with_key:  | GET | `/options/positions/{contract}` |
-| [getOptionsLiquidation()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L3678) | :closed_lock_with_key:  | GET | `/options/position_close` |
-| [submitOptionsOrder()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L3691) | :closed_lock_with_key:  | POST | `/options/orders` |
-| [getOptionsOrders()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L3703) | :closed_lock_with_key:  | GET | `/options/orders` |
-| [cancelAllOpenOptionsOrders()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L3715) | :closed_lock_with_key:  | DELETE | `/options/orders` |
-| [getOptionsOrder()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L3729) | :closed_lock_with_key:  | GET | `/options/orders/{order_id}` |
-| [cancelOptionsOrder()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L3741) | :closed_lock_with_key:  | DELETE | `/options/orders/{order_id}` |
-| [submitOptionsCountdownCancel()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L3760) | :closed_lock_with_key:  | POST | `/options/countdown_cancel_all` |
-| [getOptionsPersonalHistory()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L3776) | :closed_lock_with_key:  | GET | `/options/my_trades` |
-| [setOptionsMMPSettings()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L3788) | :closed_lock_with_key:  | POST | `/options/mmp` |
-| [getOptionsMMPSettings()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L3800) | :closed_lock_with_key:  | GET | `/options/mmp` |
-| [resetOptionsMMPSettings()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L3812) | :closed_lock_with_key:  | POST | `/options/mmp/reset` |
-| [getLendingCurrencies()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L3828) |  | GET | `/earn/uni/currencies` |
-| [getLendingCurrency()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L3838) |  | GET | `/earn/uni/currencies/{currency}` |
-| [submitLendOrRedeemOrder()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L3848) | :closed_lock_with_key:  | POST | `/earn/uni/lends` |
-| [getLendingOrders()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L3858) | :closed_lock_with_key:  | GET | `/earn/uni/lends` |
-| [updateLendingOrder()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L3870) | :closed_lock_with_key:  | PATCH | `/earn/uni/lends` |
-| [getLendingRecords()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L3883) | :closed_lock_with_key:  | GET | `/earn/uni/lend_records` |
-| [getLendingTotalInterest()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L3896) | :closed_lock_with_key:  | GET | `/earn/uni/interests/{currency}` |
-| [getLendingInterestRecords()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L3909) | :closed_lock_with_key:  | GET | `/earn/uni/interest_records` |
-| [updateInterestReinvestment()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L3922) | :closed_lock_with_key:  | PUT | `/earn/uni/interest_reinvest` |
-| [getLendingInterestStatus()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L3938) | :closed_lock_with_key:  | GET | `/earn/uni/interest_status/{currency}` |
-| [getLendingAnnualizedTrendChart()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L3953) | :closed_lock_with_key:  | GET | `/earn/uni/chart` |
-| [getLendingEstimatedRates()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L3961) | :closed_lock_with_key:  | GET | `/earn/uni/rate` |
-| [submitLoanOrder()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L3978) | :closed_lock_with_key:  | POST | `/loan/collateral/orders` |
-| [getLoanOrders()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L3988) | :closed_lock_with_key:  | GET | `/loan/collateral/orders` |
-| [getLoanOrder()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L3998) | :closed_lock_with_key:  | GET | `/loan/collateral/orders/{order_id}` |
-| [submitLoanRepay()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L4011) | :closed_lock_with_key:  | POST | `/loan/collateral/repay` |
-| [getLoanRepaymentHistory()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L4028) | :closed_lock_with_key:  | GET | `/loan/collateral/repay_records` |
-| [updateLoanCollateral()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L4040) | :closed_lock_with_key:  | POST | `/loan/collateral/collaterals` |
-| [getLoanCollateralRecords()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L4050) | :closed_lock_with_key:  | GET | `/loan/collateral/collaterals` |
-| [getLoanTotalAmount()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L4064) | :closed_lock_with_key:  | GET | `/loan/collateral/total_amount` |
-| [getLoanCollateralizationRatio()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L4077) | :closed_lock_with_key:  | GET | `/loan/collateral/ltv` |
-| [getLoanSupportedCurrencies()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L4093) |  | GET | `/loan/collateral/currencies` |
-| [submitMultiLoanOrder()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L4113) | :closed_lock_with_key:  | POST | `/loan/multi_collateral/orders` |
-| [getMultiLoanOrders()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L4125) | :closed_lock_with_key:  | GET | `/loan/multi_collateral/orders` |
-| [getMultiLoanOrder()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L4137) | :closed_lock_with_key:  | GET | `/loan/multi_collateral/orders/{order_id}` |
-| [repayMultiLoan()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L4147) | :closed_lock_with_key:  | POST | `/loan/multi_collateral/repay` |
-| [getMultiLoanRepayRecords()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L4157) | :closed_lock_with_key:  | GET | `/loan/multi_collateral/repay` |
-| [updateMultiLoan()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L4169) | :closed_lock_with_key:  | POST | `/loan/multi_collateral/mortgage` |
-| [getMultiLoanAdjustmentRecords()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L4181) | :closed_lock_with_key:  | GET | `/loan/multi_collateral/mortgage` |
-| [getMultiLoanCurrencyQuota()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L4193) | :closed_lock_with_key:  | GET | `/loan/multi_collateral/currency_quota` |
-| [getMultiLoanSupportedCurrencies()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L4205) |  | GET | `/loan/multi_collateral/currencies` |
-| [getMultiLoanRatio()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L4214) |  | GET | `/loan/multi_collateral/ltv` |
-| [getMultiLoanFixedRates()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L4223) |  | GET | `/loan/multi_collateral/fixed_rate` |
-| [getMultiLoanCurrentRates()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L4236) |  | GET | `/loan/multi_collateral/current_rate` |
-| [submitEth2Swap()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L4259) | :closed_lock_with_key:  | POST | `/earn/staking/eth2/swap` |
-| [getEth2RateHistory()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L4270) | :closed_lock_with_key:  | GET | `/earn/staking/eth2/rate_records` |
-| [getDualInvestmentProducts()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L4281) |  | GET | `/earn/dual/investment_plan` |
-| [getDualInvestmentOrders()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L4292) | :closed_lock_with_key:  | GET | `/earn/dual/orders` |
-| [submitDualInvestmentOrder()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L4304) | :closed_lock_with_key:  | POST | `/earn/dual/orders` |
-| [getStructuredProducts()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L4319) |  | GET | `/earn/structured/products` |
-| [getStructuredProductOrders()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L4331) | :closed_lock_with_key:  | GET | `/earn/structured/orders` |
-| [submitStructuredProductOrder()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L4343) | :closed_lock_with_key:  | POST | `/earn/structured/orders` |
-| [getStakingCoins()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L4356) | :closed_lock_with_key:  | GET | `/earn/staking/coins` |
-| [submitStakingSwap()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L4369) | :closed_lock_with_key:  | POST | `/earn/staking/swap` |
-| [getAccountDetail()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L4388) | :closed_lock_with_key:  | GET | `/account/detail` |
-| [getAccountRateLimit()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L4397) | :closed_lock_with_key:  | GET | `/account/rate_limit` |
-| [createStpGroup()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L4407) | :closed_lock_with_key:  | POST | `/account/stp_groups` |
-| [getStpGroups()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L4417) | :closed_lock_with_key:  | GET | `/account/stp_groups` |
-| [getStpGroupUsers()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L4427) | :closed_lock_with_key:  | GET | `/account/stp_groups/{stp_id}/users` |
-| [addUsersToStpGroup()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L4437) | :closed_lock_with_key:  | POST | `/account/stp_groups/{stp_id}/users` |
-| [deleteUserFromStpGroup()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L4453) | :closed_lock_with_key:  | DELETE | `/account/stp_groups/{stp_id}/users` |
-| [setGTDeduction()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L4471) | :closed_lock_with_key:  | POST | `/account/debit_fee` |
-| [getGTDeduction()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L4482) | :closed_lock_with_key:  | GET | `/account/debit_fee` |
-| [getAgencyTransactionHistory()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L4498) | :closed_lock_with_key:  | GET | `/rebate/agency/transaction_history` |
-| [getAgencyCommissionHistory()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L4511) | :closed_lock_with_key:  | GET | `/rebate/agency/commission_history` |
-| [getPartnerTransactionHistory()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L4525) | :closed_lock_with_key:  | GET | `/rebate/partner/transaction_history` |
-| [getPartnerCommissionHistory()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L4540) | :closed_lock_with_key:  | GET | `/rebate/partner/commission_history` |
-| [getPartnerSubordinateList()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L4563) | :closed_lock_with_key:  | GET | `/rebate/partner/sub_list` |
-| [getBrokerCommissionHistory()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L4577) | :closed_lock_with_key:  | GET | `/rebate/broker/commission_history` |
-| [getBrokerTransactionHistory()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L4590) | :closed_lock_with_key:  | GET | `/rebate/broker/transaction_history` |
-| [getUserRebateInfo()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L4599) | :closed_lock_with_key:  | GET | `/rebate/user/info` |
+| [getSystemMaintenanceStatus()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L421) |  | GET | `/v1/public/system_info` |
+| [submitWithdrawal()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L438) | :closed_lock_with_key:  | POST | `/withdrawals` |
+| [submitSpotMainAccountTransfer()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L452) | :closed_lock_with_key:  | POST | `/withdrawals/push` |
+| [cancelWithdrawal()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L468) | :closed_lock_with_key:  | DELETE | `/withdrawals/{withdrawal_id}` |
+| [getCurrencyChains()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L485) |  | GET | `/wallet/currency_chains` |
+| [createDepositAddress()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L495) | :closed_lock_with_key:  | GET | `/wallet/deposit_address` |
+| [getWithdrawalRecords()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L509) | :closed_lock_with_key:  | GET | `/wallet/withdrawals` |
+| [getDepositRecords()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L523) | :closed_lock_with_key:  | GET | `/wallet/deposits` |
+| [submitTransfer()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L542) | :closed_lock_with_key:  | POST | `/wallet/transfers` |
+| [submitMainSubTransfer()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L554) | :closed_lock_with_key:  | POST | `/wallet/sub_account_transfers` |
+| [getMainSubTransfers()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L568) | :closed_lock_with_key:  | GET | `/wallet/sub_account_transfers` |
+| [submitSubToSubTransfer()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L582) | :closed_lock_with_key:  | POST | `/wallet/sub_account_to_sub_account` |
+| [getTransferStatus()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L597) | :closed_lock_with_key:  | GET | `/wallet/order_status` |
+| [getWithdrawalStatus()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L613) | :closed_lock_with_key:  | GET | `/wallet/withdraw_status` |
+| [getSubBalance()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L628) | :closed_lock_with_key:  | GET | `/wallet/sub_account_balances` |
+| [getSubMarginBalances()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L643) | :closed_lock_with_key:  | GET | `/wallet/sub_account_margin_balances` |
+| [getSubFuturesBalances()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L655) | :closed_lock_with_key:  | GET | `/wallet/sub_account_futures_balances` |
+| [getSubCrossMarginBalances()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L668) | :closed_lock_with_key:  | GET | `/wallet/sub_account_cross_margin_balances` |
+| [getSavedAddresses()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L680) | :closed_lock_with_key:  | GET | `/wallet/saved_address` |
+| [getTradingFees()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L690) | :closed_lock_with_key:  | GET | `/wallet/fee` |
+| [getBalances()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L711) | :closed_lock_with_key:  | GET | `/wallet/total_balance` |
+| [getSmallBalances()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L720) | :closed_lock_with_key:  | GET | `/wallet/small_balance` |
+| [convertSmallBalance()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L730) | :closed_lock_with_key:  | POST | `/wallet/small_balance` |
+| [getSmallBalanceHistory()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L743) | :closed_lock_with_key:  | GET | `/wallet/small_balance_history` |
+| [getPushOrders()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L755) | :closed_lock_with_key:  | GET | `/wallet/push` |
+| [createSubAccount()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L770) | :closed_lock_with_key:  | POST | `/sub_accounts` |
+| [getSubAccounts()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L781) | :closed_lock_with_key:  | GET | `/sub_accounts` |
+| [getSubAccount()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L791) | :closed_lock_with_key:  | GET | `/sub_accounts/{user_id}` |
+| [createSubAccountApiKey()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L801) | :closed_lock_with_key:  | POST | `/sub_accounts/{user_id}/keys` |
+| [getSubAccountApiKeys()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L814) | :closed_lock_with_key:  | GET | `/sub_accounts/{user_id}/keys` |
+| [updateSubAccountApiKey()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L826) | :closed_lock_with_key:  | PUT | `/sub_accounts/{user_id}/keys/{key}` |
+| [deleteSubAccountApiKey()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L837) | :closed_lock_with_key:  | DELETE | `/sub_accounts/{user_id}/keys/{key}` |
+| [getSubAccountApiKey()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L852) | :closed_lock_with_key:  | GET | `/sub_accounts/{user_id}/keys/{key}` |
+| [lockSubAccount()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L867) | :closed_lock_with_key:  | POST | `/sub_accounts/{user_id}/lock` |
+| [unlockSubAccount()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L877) | :closed_lock_with_key:  | POST | `/sub_accounts/{user_id}/unlock` |
+| [getSubAccountMode()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L891) | :closed_lock_with_key:  | GET | `/sub_accounts/unified_mode` |
+| [getUnifiedAccountInfo()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L907) | :closed_lock_with_key:  | GET | `/unified/accounts` |
+| [getUnifiedMaxBorrow()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L923) | :closed_lock_with_key:  | GET | `/unified/borrowable` |
+| [getUnifiedMaxTransferable()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L939) | :closed_lock_with_key:  | GET | `/unified/transferable` |
+| [getUnifiedMaxTransferables()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L954) | :closed_lock_with_key:  | GET | `/unified/transferables` |
+| [getUnifiedBatchMaxBorrowable()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L963) | :closed_lock_with_key:  | GET | `/unified/batch_borrowable` |
+| [submitUnifiedBorrowOrRepay()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L981) | :closed_lock_with_key:  | POST | `/unified/loans` |
+| [getUnifiedLoans()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L993) | :closed_lock_with_key:  | GET | `/unified/loans` |
+| [getUnifiedLoanRecords()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L1003) | :closed_lock_with_key:  | GET | `/unified/loan_records` |
+| [getUnifiedInterestRecords()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L1015) | :closed_lock_with_key:  | GET | `/unified/interest_records` |
+| [getUnifiedRiskUnitDetails()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L1026) | :closed_lock_with_key:  | GET | `/unified/risk_units` |
+| [setUnifiedAccountMode()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L1038) | :closed_lock_with_key:  | PUT | `/unified/unified_mode` |
+| [getUnifiedAccountMode()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L1047) | :closed_lock_with_key:  | GET | `/unified/unified_mode` |
+| [getUnifiedEstimateRate()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L1059) | :closed_lock_with_key:  | GET | `/unified/estimate_rate` |
+| [getUnifiedCurrencyDiscountTiers()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L1070) |  | GET | `/unified/currency_discount_tiers` |
+| [getLoanMarginTiers()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L1082) |  | GET | `/unified/loan_margin_tiers` |
+| [portfolioMarginCalculate()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L1099) |  | POST | `/unified/portfolio_calculator` |
+| [getUserCurrencyLeverageConfig()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L1113) | :closed_lock_with_key:  | GET | `/unified/leverage/user_currency_config` |
+| [getUserCurrencyLeverageSettings()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L1127) | :closed_lock_with_key:  | GET | `/unified/leverage/user_currency_setting` |
+| [updateUserCurrencyLeverage()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L1142) | :closed_lock_with_key:  | POST | `/unified/leverage/user_currency_setting` |
+| [getUnifiedLoanCurrencies()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L1157) | :closed_lock_with_key:  | GET | `/unified/currencies` |
+| [getHistoricalLendingRates()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L1169) | :closed_lock_with_key:  | GET | `/unified/history_loan_rate` |
+| [submitUnifiedLoanRepay()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L1175) | :closed_lock_with_key:  | POST | `/unified/loans/repay` |
+| [getSpotCurrencies()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L1195) |  | GET | `/spot/currencies` |
+| [getSpotCurrency()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L1205) |  | GET | `/spot/currencies/{currency}` |
+| [getSpotCurrencyPairs()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L1214) |  | GET | `/spot/currency_pairs` |
+| [getSpotCurrencyPair()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L1224) |  | GET | `/spot/currency_pairs/{currency_pair}` |
+| [getSpotTicker()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L1238) |  | GET | `/spot/tickers` |
+| [getSpotOrderBook()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L1253) |  | GET | `/spot/order_book` |
+| [getSpotTrades()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L1266) |  | GET | `/spot/trades` |
+| [getSpotCandles()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L1278) |  | GET | `/spot/candlesticks` |
+| [getSpotFeeRates()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L1290) | :closed_lock_with_key:  | GET | `/spot/fee` |
+| [getSpotBatchFeeRates()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L1299) | :closed_lock_with_key:  | GET | `/spot/batch_fee` |
+| [getSpotAccounts()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L1311) | :closed_lock_with_key:  | GET | `/spot/accounts` |
+| [getSpotAccountBook()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L1323) | :closed_lock_with_key:  | GET | `/spot/account_book` |
+| [submitSpotBatchOrders()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L1342) | :closed_lock_with_key:  | POST | `/spot/batch_orders` |
+| [getSpotOpenOrders()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L1369) | :closed_lock_with_key:  | GET | `/spot/open_orders` |
+| [submitSpotClosePosCrossDisabled()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L1385) | :closed_lock_with_key:  | POST | `/spot/cross_liquidate_orders` |
+| [submitSpotOrder()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L1401) | :closed_lock_with_key:  | POST | `/spot/orders` |
+| [getSpotOrders()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L1418) | :closed_lock_with_key:  | GET | `/spot/orders` |
+| [cancelSpotOpenOrders()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L1433) | :closed_lock_with_key:  | DELETE | `/spot/orders` |
+| [batchCancelSpotOrders()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L1461) | :closed_lock_with_key:  | POST | `/spot/cancel_batch_orders` |
+| [getSpotOrder()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L1486) | :closed_lock_with_key:  | GET | `/spot/orders/{order_id}` |
+| [updateSpotOrder()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L1503) | :closed_lock_with_key:  | PATCH | `/spot/orders/{order_id}` |
+| [cancelSpotOrder()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L1531) | :closed_lock_with_key:  | DELETE | `/spot/orders/{order_id}` |
+| [getSpotTradingHistory()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L1553) | :closed_lock_with_key:  | GET | `/spot/my_trades` |
+| [submitSpotCountdownOrders()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L1582) | :closed_lock_with_key:  | POST | `/spot/countdown_cancel_all` |
+| [batchUpdateSpotOrders()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L1601) | :closed_lock_with_key:  | POST | `/spot/amend_batch_orders` |
+| [getSpotInsuranceHistory()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L1628) | :closed_lock_with_key:  | GET | `/spot/insurance_history` |
+| [submitSpotPriceTriggerOrder()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L1642) | :closed_lock_with_key:  | POST | `/spot/price_orders` |
+| [getSpotAutoOrders()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L1654) | :closed_lock_with_key:  | GET | `/spot/price_orders` |
+| [cancelAllOpenSpotOrders()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L1666) | :closed_lock_with_key:  | DELETE | `/spot/price_orders` |
+| [getPriceTriggeredOrder()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L1679) | :closed_lock_with_key:  | GET | `/spot/price_orders/{order_id}` |
+| [cancelSpotTriggeredOrder()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L1691) | :closed_lock_with_key:  | DELETE | `/spot/price_orders/{order_id}` |
+| [setCollateralCurrency()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L1705) | :closed_lock_with_key:  | POST | `/unified/collateral_currencies` |
+| [getMarginAccounts()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L1726) | :closed_lock_with_key:  | GET | `/margin/accounts` |
+| [getMarginBalanceHistory()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L1740) | :closed_lock_with_key:  | GET | `/margin/account_book` |
+| [getFundingAccounts()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L1758) | :closed_lock_with_key:  | GET | `/margin/funding_accounts` |
+| [updateAutoRepaymentSetting()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L1776) | :closed_lock_with_key:  | POST | `/margin/auto_repay` |
+| [getAutoRepaymentSetting()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L1787) | :closed_lock_with_key:  | GET | `/margin/auto_repay` |
+| [getMarginTransferableAmount()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L1801) | :closed_lock_with_key:  | GET | `/margin/transferable` |
+| [getCrossMarginCurrencies()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L1818) |  | GET | `/margin/cross/currencies` |
+| [getCrossMarginCurrency()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L1829) |  | GET | `/margin/cross/currencies/{currency}` |
+| [getCrossMarginAccount()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L1841) | :closed_lock_with_key:  | GET | `/margin/cross/accounts` |
+| [getCrossMarginAccountHistory()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L1854) | :closed_lock_with_key:  | GET | `/margin/cross/account_book` |
+| [submitCrossMarginBorrowLoan()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L1871) | :closed_lock_with_key:  | POST | `/margin/cross/loans` |
+| [getCrossMarginBorrowHistory()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L1886) | :closed_lock_with_key:  | GET | `/margin/cross/loans` |
+| [getCrossMarginBorrowLoan()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L1899) | :closed_lock_with_key:  | GET | `/margin/cross/loans/{loan_id}` |
+| [submitCrossMarginRepayment()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L1914) | :closed_lock_with_key:  | POST | `/margin/cross/repayments` |
+| [getCrossMarginRepayments()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L1930) | :closed_lock_with_key:  | GET | `/margin/cross/repayments` |
+| [getCrossMarginInterestRecords()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L1943) | :closed_lock_with_key:  | GET | `/margin/cross/interest_records` |
+| [getCrossMarginTransferableAmount()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L1959) | :closed_lock_with_key:  | GET | `/margin/cross/transferable` |
+| [getEstimatedInterestRates()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L1975) | :closed_lock_with_key:  | GET | `/margin/cross/estimate_rate` |
+| [getCrossMarginBorrowableAmount()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L1989) | :closed_lock_with_key:  | GET | `/margin/cross/borrowable` |
+| [getMarginUserLoanTiers()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L2002) | :closed_lock_with_key:  | GET | `/margin/user/loan_margin_tiers` |
+| [getMarginPublicLoanTiers()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L2018) |  | GET | `/margin/loan_margin_tiers` |
+| [setMarginUserLeverage()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L2034) | :closed_lock_with_key:  | POST | `/margin/leverage/user_market_setting` |
+| [getMarginUserAccounts()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L2051) | :closed_lock_with_key:  | GET | `/margin/user/account` |
+| [getLendingMarkets()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L2066) |  | GET | `/margin/uni/currency_pairs` |
+| [getLendingMarket()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L2081) |  | GET | `/margin/uni/currency_pairs/{currency_pair}` |
+| [getEstimatedInterestRate()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L2093) | :closed_lock_with_key:  | GET | `/margin/uni/estimate_rate` |
+| [submitMarginUNIBorrowOrRepay()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L2103) | :closed_lock_with_key:  | POST | `/margin/uni/loans` |
+| [getMarginUNILoans()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L2119) | :closed_lock_with_key:  | GET | `/margin/uni/loans` |
+| [getMarginUNILoanRecords()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L2129) | :closed_lock_with_key:  | GET | `/margin/uni/loan_records` |
+| [getMarginUNIInterestRecords()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L2141) | :closed_lock_with_key:  | GET | `/margin/uni/interest_records` |
+| [getMarginUNIMaxBorrow()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L2153) | :closed_lock_with_key:  | GET | `/margin/uni/borrowable` |
+| [getFlashSwapCurrencyPairs()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L2169) |  | GET | `/flash_swap/currency_pairs` |
+| [submitFlashSwapOrder()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L2185) | :closed_lock_with_key:  | POST | `/flash_swap/orders` |
+| [getFlashSwapOrders()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L2197) | :closed_lock_with_key:  | GET | `/flash_swap/orders` |
+| [getFlashSwapOrder()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L2209) | :closed_lock_with_key:  | GET | `/flash_swap/orders/{order_id}` |
+| [submitFlashSwapOrderPreview()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L2219) | :closed_lock_with_key:  | POST | `/flash_swap/orders/preview` |
+| [getFuturesContracts()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L2236) |  | GET | `/futures/{settle}/contracts` |
+| [getFuturesContract()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L2251) |  | GET | `/futures/{settle}/contracts/{contract}` |
+| [getFuturesOrderBook()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L2266) |  | GET | `/futures/{settle}/order_book` |
+| [getFuturesTrades()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L2279) |  | GET | `/futures/{settle}/trades` |
+| [getFuturesCandles()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L2294) |  | GET | `/futures/{settle}/candlesticks` |
+| [getPremiumIndexKLines()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L2307) |  | GET | `/futures/{settle}/premium_index` |
+| [getFuturesTickers()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L2320) |  | GET | `/futures/{settle}/tickers` |
+| [getFundingRates()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L2337) |  | GET | `/futures/{settle}/funding_rate` |
+| [getFuturesInsuranceBalanceHistory()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L2356) |  | GET | `/futures/{settle}/insurance` |
+| [getFuturesStats()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L2375) |  | GET | `/futures/{settle}/contract_stats` |
+| [getIndexConstituents()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L2386) |  | GET | `/futures/{settle}/index_constituents/{index}` |
+| [getLiquidationHistory()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L2403) |  | GET | `/futures/{settle}/liq_orders` |
+| [getRiskLimitTiers()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L2420) |  | GET | `/futures/{settle}/risk_limit_tiers` |
+| [getFuturesAccount()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L2431) | :closed_lock_with_key:  | GET | `/futures/{settle}/accounts` |
+| [getFuturesAccountBook()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L2445) | :closed_lock_with_key:  | GET | `/futures/{settle}/account_book` |
+| [getFuturesPositions()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L2458) | :closed_lock_with_key:  | GET | `/futures/{settle}/positions` |
+| [getFuturesPosition()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L2471) | :closed_lock_with_key:  | GET | `/futures/{settle}/positions/{contract}` |
+| [updateFuturesMargin()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L2486) | :closed_lock_with_key:  | POST | `/futures/{settle}/positions/{contract}/margin` |
+| [updateFuturesLeverage()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L2503) | :closed_lock_with_key:  | POST | `/futures/{settle}/positions/{contract}/leverage` |
+| [updateFuturesPositionMode()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L2522) | :closed_lock_with_key:  | POST | `/futures/{settle}/positions/cross_mode` |
+| [updatePositionRiskLimit()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L2539) | :closed_lock_with_key:  | POST | `/futures/{settle}/positions/{contract}/risk_limit` |
+| [updateFuturesDualMode()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L2559) | :closed_lock_with_key:  | POST | `/futures/{settle}/dual_mode` |
+| [getDualModePosition()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L2575) | :closed_lock_with_key:  | GET | `/futures/{settle}/dual_comp/positions/{contract}` |
+| [updateDualModePositionMargin()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L2590) | :closed_lock_with_key:  | POST | `/futures/{settle}/dual_comp/positions/{contract}/margin` |
+| [updateDualModePositionLeverage()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L2606) | :closed_lock_with_key:  | POST | `/futures/{settle}/dual_comp/positions/{contract}/leverage` |
+| [updateDualModePositionRiskLimit()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L2622) | :closed_lock_with_key:  | POST | `/futures/{settle}/dual_comp/positions/{contract}/risk_limit` |
+| [submitFuturesOrder()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L2649) | :closed_lock_with_key:  | POST | `/futures/{settle}/orders` |
+| [getFuturesOrders()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L2670) | :closed_lock_with_key:  | GET | `/futures/{settle}/orders` |
+| [cancelAllFuturesOrders()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L2685) | :closed_lock_with_key:  | DELETE | `/futures/{settle}/orders` |
+| [getFuturesOrdersByTimeRange()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L2705) | :closed_lock_with_key:  | GET | `/futures/{settle}/orders_timerange` |
+| [submitFuturesBatchOrders()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L2728) | :closed_lock_with_key:  | POST | `/futures/{settle}/batch_orders` |
+| [getFuturesOrder()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L2753) | :closed_lock_with_key:  | GET | `/futures/{settle}/orders/{order_id}` |
+| [cancelFuturesOrder()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L2770) | :closed_lock_with_key:  | DELETE | `/futures/{settle}/orders/{order_id}` |
+| [updateFuturesOrder()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L2793) | :closed_lock_with_key:  | PUT | `/futures/{settle}/orders/{order_id}` |
+| [getFuturesTradingHistory()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L2814) | :closed_lock_with_key:  | GET | `/futures/{settle}/my_trades` |
+| [getFuturesTradingHistoryByTimeRange()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L2829) | :closed_lock_with_key:  | GET | `/futures/{settle}/my_trades_timerange` |
+| [getFuturesPositionHistory()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L2842) | :closed_lock_with_key:  | GET | `/futures/{settle}/position_close` |
+| [getFuturesLiquidationHistory()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L2855) | :closed_lock_with_key:  | GET | `/futures/{settle}/liquidates` |
+| [getFuturesAutoDeleveragingHistory()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L2868) | :closed_lock_with_key:  | GET | `/futures/{settle}/auto_deleverages` |
+| [setFuturesOrderCancelCountdown()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L2885) | :closed_lock_with_key:  | POST | `/futures/{settle}/countdown_cancel_all` |
+| [getFuturesUserTradingFees()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L2902) | :closed_lock_with_key:  | GET | `/futures/{settle}/fee` |
+| [batchCancelFuturesOrders()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L2920) | :closed_lock_with_key:  | POST | `/futures/{settle}/batch_cancel_orders` |
+| [batchUpdateFuturesOrders()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L2947) | :closed_lock_with_key:  | POST | `/futures/{settle}/batch_amend_orders` |
+| [getRiskLimitTable()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L2969) |  | GET | `/futures/{settle}/risk_limit_table` |
+| [submitFuturesPriceTriggeredOrder()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L2982) | :closed_lock_with_key:  | POST | `/futures/{settle}/price_orders` |
+| [getFuturesAutoOrders()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L2995) | :closed_lock_with_key:  | GET | `/futures/{settle}/price_orders` |
+| [cancelAllOpenFuturesOrders()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L3008) | :closed_lock_with_key:  | DELETE | `/futures/{settle}/price_orders` |
+| [getFuturesPriceTriggeredOrder()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L3024) | :closed_lock_with_key:  | GET | `/futures/{settle}/price_orders/{order_id}` |
+| [cancelFuturesPriceTriggeredOrder()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L3039) | :closed_lock_with_key:  | DELETE | `/futures/{settle}/price_orders/{order_id}` |
+| [updateFuturesPriceTriggeredOrder()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L3054) | :closed_lock_with_key:  | PUT | `/futures/{settle}/price_orders/{order_id}` |
+| [getFuturesPositionCloseHistory()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L3063) | :closed_lock_with_key:  | GET | `/futures/{settle}/position_close_history` |
+| [getFuturesInsuranceHistory()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L3072) | :closed_lock_with_key:  | GET | `/futures/{settle}/insurance` |
+| [getAllDeliveryContracts()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L3089) |  | GET | `/delivery/{settle}/contracts` |
+| [getDeliveryContract()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L3101) |  | GET | `/delivery/{settle}/contracts/{contract}` |
+| [getDeliveryOrderBook()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L3116) |  | GET | `/delivery/{settle}/order_book` |
+| [getDeliveryTrades()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L3129) |  | GET | `/delivery/{settle}/trades` |
+| [getDeliveryCandles()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L3143) |  | GET | `/delivery/{settle}/candlesticks` |
+| [getDeliveryTickers()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L3154) |  | GET | `/delivery/{settle}/tickers` |
+| [getDeliveryInsuranceBalanceHistory()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L3171) |  | GET | `/delivery/{settle}/insurance` |
+| [getDeliveryAccount()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L3190) | :closed_lock_with_key:  | GET | `/delivery/{settle}/accounts` |
+| [getDeliveryBook()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L3201) | :closed_lock_with_key:  | GET | `/delivery/{settle}/account_book` |
+| [getDeliveryPositions()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L3212) | :closed_lock_with_key:  | GET | `/delivery/{settle}/positions` |
+| [getDeliveryPosition()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L3222) | :closed_lock_with_key:  | GET | `/delivery/{settle}/positions/{contract}` |
+| [updateDeliveryMargin()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L3237) | :closed_lock_with_key:  | POST | `/delivery/{settle}/positions/{contract}/margin` |
+| [updateDeliveryLeverage()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L3255) | :closed_lock_with_key:  | POST | `/delivery/{settle}/positions/{contract}/leverage` |
+| [updateDeliveryRiskLimit()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L3273) | :closed_lock_with_key:  | POST | `/delivery/{settle}/positions/{contract}/risk_limit` |
+| [submitDeliveryOrder()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L3293) | :closed_lock_with_key:  | POST | `/delivery/{settle}/orders` |
+| [getDeliveryOrders()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L3308) | :closed_lock_with_key:  | GET | `/delivery/{settle}/orders` |
+| [cancelAllDeliveryOrders()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L3321) | :closed_lock_with_key:  | DELETE | `/delivery/{settle}/orders` |
+| [getDeliveryOrder()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L3340) | :closed_lock_with_key:  | GET | `/delivery/{settle}/orders/{order_id}` |
+| [cancelDeliveryOrder()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L3355) | :closed_lock_with_key:  | DELETE | `/delivery/{settle}/orders/{order_id}` |
+| [getDeliveryTradingHistory()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L3370) | :closed_lock_with_key:  | GET | `/delivery/{settle}/my_trades` |
+| [getDeliveryClosedPositions()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L3383) | :closed_lock_with_key:  | GET | `/delivery/{settle}/position_close` |
+| [getDeliveryLiquidationHistory()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L3396) | :closed_lock_with_key:  | GET | `/delivery/{settle}/liquidates` |
+| [getDeliverySettlementHistory()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L3409) | :closed_lock_with_key:  | GET | `/delivery/{settle}/settlements` |
+| [submitDeliveryTriggeredOrder()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L3422) | :closed_lock_with_key:  | POST | `/delivery/{settle}/price_orders` |
+| [getDeliveryAutoOrders()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L3437) | :closed_lock_with_key:  | GET | `/delivery/{settle}/price_orders` |
+| [cancelAllOpenDeliveryOrders()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L3450) | :closed_lock_with_key:  | DELETE | `/delivery/{settle}/price_orders` |
+| [getDeliveryTriggeredOrder()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L3466) | :closed_lock_with_key:  | GET | `/delivery/{settle}/price_orders/{order_id}` |
+| [cancelTriggeredDeliveryOrder()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L3481) | :closed_lock_with_key:  | DELETE | `/delivery/{settle}/price_orders/{order_id}` |
+| [getOptionsUnderlyings()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L3500) |  | GET | `/options/underlyings` |
+| [getOptionsExpirationTimes()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L3510) |  | GET | `/options/expirations` |
+| [getOptionsContracts()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L3520) |  | GET | `/options/contracts` |
+| [getOptionsContract()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L3533) |  | GET | `/options/contracts/{contract}` |
+| [getOptionsSettlementHistory()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L3543) |  | GET | `/options/settlements` |
+| [getOptionsContractSettlement()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L3555) |  | GET | `/options/settlements/{contract}` |
+| [getOptionsMySettlements()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L3570) | :closed_lock_with_key:  | GET | `/options/my_settlements` |
+| [getOptionsOrderBook()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L3584) |  | GET | `/options/order_book` |
+| [getOptionsTickers()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L3596) |  | GET | `/options/tickers` |
+| [getOptionsUnderlyingTicker()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L3610) |  | GET | `/options/underlying/tickers/{underlying}` |
+| [getOptionsCandles()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L3624) |  | GET | `/options/candlesticks` |
+| [getOptionsUnderlyingCandles()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L3634) |  | GET | `/options/underlying/candlesticks` |
+| [getOptionsTrades()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L3646) |  | GET | `/options/trades` |
+| [getOptionsAccount()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L3655) | :closed_lock_with_key:  | GET | `/options/accounts` |
+| [getOptionsAccountChange()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L3665) | :closed_lock_with_key:  | GET | `/options/account_book` |
+| [getOptionsPositionsUnderlying()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L3677) | :closed_lock_with_key:  | GET | `/options/positions` |
+| [getOptionsPositionContract()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L3689) | :closed_lock_with_key:  | GET | `/options/positions/{contract}` |
+| [getOptionsLiquidation()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L3701) | :closed_lock_with_key:  | GET | `/options/position_close` |
+| [submitOptionsOrder()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L3714) | :closed_lock_with_key:  | POST | `/options/orders` |
+| [getOptionsOrders()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L3726) | :closed_lock_with_key:  | GET | `/options/orders` |
+| [cancelAllOpenOptionsOrders()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L3738) | :closed_lock_with_key:  | DELETE | `/options/orders` |
+| [getOptionsOrder()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L3752) | :closed_lock_with_key:  | GET | `/options/orders/{order_id}` |
+| [cancelOptionsOrder()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L3764) | :closed_lock_with_key:  | DELETE | `/options/orders/{order_id}` |
+| [submitOptionsCountdownCancel()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L3783) | :closed_lock_with_key:  | POST | `/options/countdown_cancel_all` |
+| [getOptionsPersonalHistory()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L3799) | :closed_lock_with_key:  | GET | `/options/my_trades` |
+| [setOptionsMMPSettings()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L3811) | :closed_lock_with_key:  | POST | `/options/mmp` |
+| [getOptionsMMPSettings()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L3823) | :closed_lock_with_key:  | GET | `/options/mmp` |
+| [resetOptionsMMPSettings()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L3835) | :closed_lock_with_key:  | POST | `/options/mmp/reset` |
+| [getLendingCurrencies()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L3851) |  | GET | `/earn/uni/currencies` |
+| [getLendingCurrency()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L3861) |  | GET | `/earn/uni/currencies/{currency}` |
+| [submitLendOrRedeemOrder()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L3871) | :closed_lock_with_key:  | POST | `/earn/uni/lends` |
+| [getLendingOrders()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L3881) | :closed_lock_with_key:  | GET | `/earn/uni/lends` |
+| [updateLendingOrder()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L3893) | :closed_lock_with_key:  | PATCH | `/earn/uni/lends` |
+| [getLendingRecords()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L3906) | :closed_lock_with_key:  | GET | `/earn/uni/lend_records` |
+| [getLendingTotalInterest()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L3919) | :closed_lock_with_key:  | GET | `/earn/uni/interests/{currency}` |
+| [getLendingInterestRecords()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L3932) | :closed_lock_with_key:  | GET | `/earn/uni/interest_records` |
+| [updateInterestReinvestment()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L3945) | :closed_lock_with_key:  | PUT | `/earn/uni/interest_reinvest` |
+| [getLendingInterestStatus()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L3961) | :closed_lock_with_key:  | GET | `/earn/uni/interest_status/{currency}` |
+| [getLendingAnnualizedTrendChart()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L3976) | :closed_lock_with_key:  | GET | `/earn/uni/chart` |
+| [getLendingEstimatedRates()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L3984) | :closed_lock_with_key:  | GET | `/earn/uni/rate` |
+| [submitLoanOrder()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L4001) | :closed_lock_with_key:  | POST | `/loan/collateral/orders` |
+| [getLoanOrders()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L4011) | :closed_lock_with_key:  | GET | `/loan/collateral/orders` |
+| [getLoanOrder()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L4021) | :closed_lock_with_key:  | GET | `/loan/collateral/orders/{order_id}` |
+| [submitLoanRepay()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L4034) | :closed_lock_with_key:  | POST | `/loan/collateral/repay` |
+| [getLoanRepaymentHistory()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L4051) | :closed_lock_with_key:  | GET | `/loan/collateral/repay_records` |
+| [updateLoanCollateral()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L4063) | :closed_lock_with_key:  | POST | `/loan/collateral/collaterals` |
+| [getLoanCollateralRecords()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L4073) | :closed_lock_with_key:  | GET | `/loan/collateral/collaterals` |
+| [getLoanTotalAmount()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L4087) | :closed_lock_with_key:  | GET | `/loan/collateral/total_amount` |
+| [getLoanCollateralizationRatio()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L4100) | :closed_lock_with_key:  | GET | `/loan/collateral/ltv` |
+| [getLoanSupportedCurrencies()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L4116) |  | GET | `/loan/collateral/currencies` |
+| [submitMultiLoanOrder()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L4136) | :closed_lock_with_key:  | POST | `/loan/multi_collateral/orders` |
+| [getMultiLoanOrders()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L4148) | :closed_lock_with_key:  | GET | `/loan/multi_collateral/orders` |
+| [getMultiLoanOrder()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L4160) | :closed_lock_with_key:  | GET | `/loan/multi_collateral/orders/{order_id}` |
+| [repayMultiLoan()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L4170) | :closed_lock_with_key:  | POST | `/loan/multi_collateral/repay` |
+| [getMultiLoanRepayRecords()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L4180) | :closed_lock_with_key:  | GET | `/loan/multi_collateral/repay` |
+| [updateMultiLoan()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L4192) | :closed_lock_with_key:  | POST | `/loan/multi_collateral/mortgage` |
+| [getMultiLoanAdjustmentRecords()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L4204) | :closed_lock_with_key:  | GET | `/loan/multi_collateral/mortgage` |
+| [getMultiLoanCurrencyQuota()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L4216) | :closed_lock_with_key:  | GET | `/loan/multi_collateral/currency_quota` |
+| [getMultiLoanSupportedCurrencies()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L4228) |  | GET | `/loan/multi_collateral/currencies` |
+| [getMultiLoanRatio()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L4237) |  | GET | `/loan/multi_collateral/ltv` |
+| [getMultiLoanFixedRates()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L4246) |  | GET | `/loan/multi_collateral/fixed_rate` |
+| [getMultiLoanCurrentRates()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L4259) |  | GET | `/loan/multi_collateral/current_rate` |
+| [submitEth2Swap()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L4281) | :closed_lock_with_key:  | POST | `/earn/staking/eth2/swap` |
+| [getEth2RateHistory()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L4290) | :closed_lock_with_key:  | GET | `/earn/staking/eth2/rate_records` |
+| [getDualInvestmentProducts()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L4301) |  | GET | `/earn/dual/investment_plan` |
+| [getDualInvestmentOrders()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L4312) | :closed_lock_with_key:  | GET | `/earn/dual/orders` |
+| [submitDualInvestmentOrder()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L4324) | :closed_lock_with_key:  | POST | `/earn/dual/orders` |
+| [getStructuredProducts()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L4339) |  | GET | `/earn/structured/products` |
+| [getStructuredProductOrders()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L4351) | :closed_lock_with_key:  | GET | `/earn/structured/orders` |
+| [submitStructuredProductOrder()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L4363) | :closed_lock_with_key:  | POST | `/earn/structured/orders` |
+| [getStakingCoins()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L4376) | :closed_lock_with_key:  | GET | `/earn/staking/coins` |
+| [submitStakingSwap()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L4389) | :closed_lock_with_key:  | POST | `/earn/staking/swap` |
+| [getAccountDetail()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L4408) | :closed_lock_with_key:  | GET | `/account/detail` |
+| [getAccountRateLimit()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L4417) | :closed_lock_with_key:  | GET | `/account/rate_limit` |
+| [createStpGroup()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L4427) | :closed_lock_with_key:  | POST | `/account/stp_groups` |
+| [getStpGroups()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L4437) | :closed_lock_with_key:  | GET | `/account/stp_groups` |
+| [getStpGroupUsers()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L4447) | :closed_lock_with_key:  | GET | `/account/stp_groups/{stp_id}/users` |
+| [addUsersToStpGroup()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L4457) | :closed_lock_with_key:  | POST | `/account/stp_groups/{stp_id}/users` |
+| [deleteUserFromStpGroup()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L4473) | :closed_lock_with_key:  | DELETE | `/account/stp_groups/{stp_id}/users` |
+| [setGTDeduction()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L4491) | :closed_lock_with_key:  | POST | `/account/debit_fee` |
+| [getGTDeduction()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L4502) | :closed_lock_with_key:  | GET | `/account/debit_fee` |
+| [getAccountMainKeys()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L4511) | :closed_lock_with_key:  | GET | `/account/main_keys` |
+| [getAgencyTransactionHistory()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L4527) | :closed_lock_with_key:  | GET | `/rebate/agency/transaction_history` |
+| [getAgencyCommissionHistory()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L4540) | :closed_lock_with_key:  | GET | `/rebate/agency/commission_history` |
+| [getPartnerTransactionHistory()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L4554) | :closed_lock_with_key:  | GET | `/rebate/partner/transaction_history` |
+| [getPartnerCommissionHistory()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L4569) | :closed_lock_with_key:  | GET | `/rebate/partner/commission_history` |
+| [getPartnerSubordinateList()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L4592) | :closed_lock_with_key:  | GET | `/rebate/partner/sub_list` |
+| [getBrokerCommissionHistory()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L4606) | :closed_lock_with_key:  | GET | `/rebate/broker/commission_history` |
+| [getBrokerTransactionHistory()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L4619) | :closed_lock_with_key:  | GET | `/rebate/broker/transaction_history` |
+| [getUserRebateInfo()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L4628) | :closed_lock_with_key:  | GET | `/rebate/user/info` |
 
 # WebsocketAPIClient.ts
 

--- a/examples/apidoc/RestClient/getAccountMainKeys.js
+++ b/examples/apidoc/RestClient/getAccountMainKeys.js
@@ -1,0 +1,20 @@
+const { RestClient } = require('gateio-api');
+
+  // This example shows how to call this Gate.io API endpoint with either node.js, javascript (js) or typescript (ts) with the npm module "gateio-api" for Gate.io exchange
+  // This Gate.io API SDK is available on npm via "npm install gateio-api"
+  // ENDPOINT: /account/main_keys
+  // METHOD: GET
+  // PUBLIC: NO
+
+const client = new RestClient({
+  apiKey: 'insert_api_key_here',
+  apiSecret: 'insert_api_secret_here',
+});
+
+client.getAccountMainKeys(params)
+  .then((response) => {
+    console.log(response);
+  })
+  .catch((error) => {
+    console.error(error);
+  });

--- a/examples/apidoc/RestClient/getUnifiedBatchMaxBorrowable.js
+++ b/examples/apidoc/RestClient/getUnifiedBatchMaxBorrowable.js
@@ -1,0 +1,20 @@
+const { RestClient } = require('gateio-api');
+
+  // This example shows how to call this Gate.io API endpoint with either node.js, javascript (js) or typescript (ts) with the npm module "gateio-api" for Gate.io exchange
+  // This Gate.io API SDK is available on npm via "npm install gateio-api"
+  // ENDPOINT: /unified/batch_borrowable
+  // METHOD: GET
+  // PUBLIC: NO
+
+const client = new RestClient({
+  apiKey: 'insert_api_key_here',
+  apiSecret: 'insert_api_secret_here',
+});
+
+client.getUnifiedBatchMaxBorrowable(params)
+  .then((response) => {
+    console.log(response);
+  })
+  .catch((error) => {
+    console.error(error);
+  });

--- a/examples/apidoc/RestClient/updateFuturesPriceTriggeredOrder.js
+++ b/examples/apidoc/RestClient/updateFuturesPriceTriggeredOrder.js
@@ -1,0 +1,20 @@
+const { RestClient } = require('gateio-api');
+
+  // This example shows how to call this Gate.io API endpoint with either node.js, javascript (js) or typescript (ts) with the npm module "gateio-api" for Gate.io exchange
+  // This Gate.io API SDK is available on npm via "npm install gateio-api"
+  // ENDPOINT: /futures/{settle}/price_orders/{order_id}
+  // METHOD: PUT
+  // PUBLIC: NO
+
+const client = new RestClient({
+  apiKey: 'insert_api_key_here',
+  apiSecret: 'insert_api_secret_here',
+});
+
+client.updateFuturesPriceTriggeredOrder(params)
+  .then((response) => {
+    console.log(response);
+  })
+  .catch((error) => {
+    console.error(error);
+  });

--- a/llms.txt
+++ b/llms.txt
@@ -296,6 +296,53 @@ console.error(`Error in execution: `, e); // Log any errors that occur
 // Execute the function to submit a futures order
 
 ================
+File: examples/futures/testnet.ts
+================
+import { RestClient } from '../../src/index.js'; // For an easy demonstration, import from the src dir. Normally though, see below to import from the npm installed version instead.
+// import { RestClient } from 'gateio-api'; // Import the RestClient from the published version of this SDK, installed via NPM (npm install gateio-api)
+⋮----
+// Define the account object with API key and secret
+⋮----
+key: process.env.API_KEY || 'yourApiHere', // Replace 'yourApiHere' with your actual API key
+secret: process.env.API_SECRET || 'yourSecretHere', // Replace 'yourSecretHere' with your actual API secret
+⋮----
+// Initialize the RestClient with the API credentials
+⋮----
+/**
+   * To use a different base URL, use the baseUrl key. The SDK uses the live environment by default:
+   * baseUrlKey: 'live',
+   *'https://api.gateio.ws/api/v4'
+   * But you can force it to use any of the available environments. Examples below.
+   */
+⋮----
+/*
+   * Futures TestNet trading:
+   * 'https://fx-api-testnet.gateio.ws/api/v4'
+   */
+⋮----
+/**
+   * Futures live trading alternative (futures only):
+   * 'https://fx-api.gateio.ws/api/v4'
+   */
+// baseUrlKey: 'futuresLiveAlternative'
+⋮----
+async function submitFuturesOrder()
+⋮----
+// Submit a market order for futures trading
+⋮----
+settle: 'usdt', // Specify the settlement currency
+contract: 'BTC_USDT', // Specify the contract
+size: 20, // Order size: positive for long, negative for short
+price: '0', // Market order, so price is set to '0'
+tif: 'ioc', // Time in force: 'ioc' (Immediate Or Cancel)
+⋮----
+console.log('Response: ', result); // Log the response to the console
+⋮----
+console.error(`Error in execution: `, e); // Log any errors that occur
+⋮----
+// Execute the function to submit a futures order
+
+================
 File: examples/spot/getBalances.ts
 ================
 import { RestClient } from '../../src'; // For an easy demonstration, import from the src dir. Normally though, see below to import from the npm installed version instead.
@@ -556,9 +603,1688 @@ node ./examples/spot/getTickers.js
 ```
 
 ================
+File: examples/ws-api-client.ts
+================
+import { WebsocketAPIClient, WS_KEY_MAP } from '../src/index.js';
+// import { LogParams, WebsocketClient } from 'gateio-api'; // normally you should install this module via npm: `npm install gateio-api`
+⋮----
+async function start()
+⋮----
+/**
+     * Optional: authenticate in advance. This will prepare and authenticate a connection.
+     * Useful to save time for the first request but completely optional. It will also happen automatically when you make your first request.
+     */
+// console.log(new Date(), 'Authenticating in advance...');
+// await client.getWSClient().connectWSAPI('spotV4');
+// console.log(new Date(), 'Authenticating in advance...OK!');
+⋮----
+/* ============ SPOT TRADING EXAMPLES ============ */
+⋮----
+// SPOT ORDER PLACE - Submit a new spot order
+⋮----
+// SPOT ORDER CANCEL - Cancel a specific spot order
+⋮----
+// SPOT ORDER CANCEL BY IDS - Cancel orders by ID list
+⋮----
+// SPOT ORDER CANCEL BY CURRENCY PAIR - Cancel all orders for a currency pair
+⋮----
+// SPOT ORDER AMEND - Update an existing spot order
+⋮----
+// SPOT ORDER STATUS - Get status of a specific spot order
+⋮----
+// SPOT ORDER LIST - Get list of spot orders
+⋮----
+/* ============ FUTURES TRADING EXAMPLES ============ */
+⋮----
+/**
+     * Gate has different websocket groups depending on the futures product.
+     *
+     * This affects which connection your command is sent to, so make sure to pass one matching your request. Look at WS_KEY_MAP (or the examples below) for details on the available product groups.
+     */
+⋮----
+/**
+     * Also optional, as for spot. Keep in mind the first parameter (wsKey) might vary depending on which WS URL is needed.
+     */
+⋮----
+// console.log(new Date(), 'Authenticating in advance...');
+// await client.getWSClient().connectWSAPI(futuresConnectionGroup);
+// await client.getWSClient().connectWSAPI('perpFuturesUSDTV4');
+// await client.getWSClient().connectWSAPI('perpFuturesBTCV4');
+// await client.getWSClient().connectWSAPI('deliveryFuturesUSDTV4');
+// await client.getWSClient().connectWSAPI('perpFuturesBTCV4');
+// console.log(new Date(), 'Authenticating in advance...OK!');
+⋮----
+// FUTURES ORDER PLACE - Submit a new futures order
+⋮----
+// FUTURES ORDER BATCH PLACE - Submit multiple futures orders
+⋮----
+// FUTURES ORDER CANCEL - Cancel a specific futures order
+⋮----
+// FUTURES ORDER CANCEL BY IDS - Cancel futures orders by ID list
+⋮----
+// FUTURES ORDER CANCEL ALL - Cancel all open futures orders
+⋮----
+// FUTURES ORDER AMEND - Update an existing futures order
+⋮----
+// FUTURES ORDER LIST - Get list of futures orders
+⋮----
+// FUTURES ORDER STATUS - Get status of a specific futures order
+
+================
+File: examples/ws-private-perp-futures-wsapi.ts
+================
+/* eslint-disable @typescript-eslint/no-unused-vars */
+⋮----
+import { LogParams, WebsocketClient } from '../src/index.js';
+// import { LogParams, WebsocketClient } from 'gateio-api'; // normally you should install this module via npm: `npm install gateio-api`
+⋮----
+// Define a custom logger object to handle logging at different levels
+⋮----
+// Trace level logging: used for detailed debugging information
+⋮----
+// Uncomment the line below to enable trace logging
+// console.log(new Date(), 'trace', ...params);
+⋮----
+// Info level logging: used for general informational messages
+⋮----
+// Error level logging: used for error messages
+⋮----
+async function start()
+⋮----
+// See comments below about event-driven vs promise-driven. Not needed if using the promise-driven approach
+// client.on('update', (data) => {
+//   // console.info(new Date(), 'ws data received: ', JSON.stringify(data));
+//   console.info(new Date(), 'ws data received: ', JSON.stringify(data, null, 2));
+// });
+⋮----
+// Something happened, attempting to reconnect
+⋮----
+// Reconnect successful
+⋮----
+// Connection closed. If unexpected, expect reconnect -> reconnected.
+⋮----
+// Reply to a request, e.g. "subscribe"/"unsubscribe"/"authenticate"
+// See comments below about event-driven vs promise-driven. Not needed if using the promise-driven approach
+// client.on('response', (data) => {
+//   console.info(
+//     new Date(),
+//     'ws server reply ',
+//     JSON.stringify(data, null, 2),
+//     '\n',
+//   );
+// });
+⋮----
+// Optional, listen to this event if you prefer the event-driven approach.
+// See below comments on event-driven vs promise-driven.
+// client.on('authenticated', (data) => {
+//   console.error(new Date(), 'ws authenticated: ', data);
+// });
+⋮----
+/**
+     * All WebSocket API (WS API) messaging should be done via the sendWSAPIRequest method.
+     *
+     * You have two ways to handle responses on the WS API. You can either:
+     * - event-driven: process async `response` and `update` events from the websocket client, OR
+     * - promise-driven: await every call to `client.sendWSAPIRequest`, this can behave similar to using a REST API (successful responses resolve, exceptions reject).
+     */
+⋮----
+/**
+     * To authenticate, send an empty request to "futures.login". The SDK will handle all the parameters.
+     *
+     * Optional - you can inject rich types to set the response type
+     *    const loginResult = await client.sendWSAPIRequest<WSAPIResponse<WSAPILoginResponse>>('perpFuturesUSDTV4', 'futures.login');
+     */
+⋮----
+/**
+     * For other channels, the 3rd parameter should have any parameters for the request (the payload).
+     *
+     * Note that internal parameters such as "signature" etc are all handled automatically by the SDK.
+     *
+     */
+⋮----
+/**
+     * Submit futures order
+     */
+⋮----
+size: 20, // positive for long, negative for short
+⋮----
+/**
+     * Submit batch futures order
+     */
+⋮----
+size: 10, // positive for long, negative for short
+⋮----
+size: 10, // positive for long, negative for short
+⋮----
+/**
+     * Cancel futures order
+     */
+⋮----
+/**
+     * Cancel all futures orders
+     */
+⋮----
+/**
+     * Update/Amend Futures order
+     */
+⋮----
+/**
+     * Get orders list
+     */
+⋮----
+/**
+     * Get order status
+     */
+
+================
+File: examples/ws-private-perp-futures.ts
+================
+/* eslint-disable @typescript-eslint/no-unused-vars */
+import { LogParams, WebsocketClient, WsTopicRequest } from '../src/index.js';
+// import { LogParams, WebsocketClient, WsTopicRequest } from 'gateio-api'; // normally you should install this module via npm: `npm install gateio-api`
+⋮----
+// Define a custom logger object to handle logging at different levels
+⋮----
+// Trace level logging: used for detailed debugging information
+⋮----
+// Uncomment the line below to enable trace logging
+// console.log(new Date(), 'trace', ...params);
+⋮----
+// Info level logging: used for general informational messages
+⋮----
+// Error level logging: used for error messages
+⋮----
+async function start()
+⋮----
+// console.log('auth with: ', account);
+⋮----
+// Data received
+⋮----
+// Something happened, attempting to reconnect
+⋮----
+// Reconnect successful
+⋮----
+// Connection closed. If unexpected, expect reconnect -> reconnected.
+⋮----
+// Reply to a request, e.g. "subscribe"/"unsubscribe"/"authenticate"
+⋮----
+// TODO: many private topics use your user ID
+⋮----
+/**
+     * Either send one topic (with params) at a time
+     */
+// client.subscribe({
+//   topic: 'futures.usertrades',
+//   payload: [myUserID, '!all'],
+// }, 'perpFuturesUSDTV4');
+⋮----
+/**
+     * Or send multiple topics in a batch (grouped by ws connection (WsKey))
+     * You can also use strings for topics that don't have any parameters, even if you mix multiple requests into one function call:
+     */
+
+================
+File: examples/ws-private-spot-wsapi.ts
+================
+/* eslint-disable @typescript-eslint/no-unused-vars */
+⋮----
+import { LogParams, WebsocketClient } from '../src/index.js';
+// import { LogParams, WebsocketClient } from 'gateio-api'; // normally you should install this module via npm: `npm install gateio-api`
+⋮----
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+⋮----
+// Define a custom logger object to handle logging at different levels
+⋮----
+// Trace level logging: used for detailed debugging information
+⋮----
+// Uncomment the line below to enable trace logging
+// console.log(new Date(), 'trace', ...params);
+⋮----
+// Info level logging: used for general informational messages
+⋮----
+// Error level logging: used for error messages
+⋮----
+async function start()
+⋮----
+// See comments below about event-driven vs promise-driven. Not needed if using the promise-driven approach
+// client.on('update', (data) => {
+//   // console.info(new Date(), 'ws data received: ', JSON.stringify(data));
+//   console.info(new Date(), 'ws data received: ', JSON.stringify(data, null, 2));
+// });
+⋮----
+// Something happened, attempting to reconnect
+⋮----
+// Reconnect successful
+⋮----
+// Connection closed. If unexpected, expect reconnect -> reconnected.
+⋮----
+// Reply to a request, e.g. "subscribe"/"unsubscribe"/"authenticate"
+// See comments below about event-driven vs promise-driven. Not needed if using the promise-driven approach
+// client.on('response', (data) => {
+//   console.info(
+//     new Date(),
+//     'ws server reply ',
+//     JSON.stringify(data, null, 2),
+//     '\n',
+//   );
+// });
+⋮----
+// Optional, listen to this event if you prefer the event-driven approach.
+// See below comments on event-driven vs promise-driven.
+// client.on('authenticated', (data) => {
+//   console.error(new Date(), 'ws authenticated: ', data);
+// });
+⋮----
+/**
+     * All WebSocket API (WS API) messaging should be done via the sendWSAPIRequest method.
+     *
+     * You have two ways to handle responses on the WS API. You can either:
+     * - event-driven: process async `response` and `update` events from the websocket client, OR
+     * - promise-driven: await every call to `client.sendWSAPIRequest`, this can behave similar to using a REST API (successful responses resolve, exceptions reject).
+     */
+⋮----
+/**
+     * No need to authenticate first - the SDK will automatically authenticate for you when you send your first request.
+     *
+     * Unless you want to prepare the connection before your first request, to speed up your first request.
+     */
+⋮----
+/**
+     * For other channels, the 3rd parameter should have any parameters for the request (the payload that goes in req_param in the docs).
+     *
+     * See WsAPIRequestsTopicMap for a topic->parameter map.
+     *
+     * Note that internal parameters such as "signature" etc are all handled automatically by the SDK.
+     */
+⋮----
+/**
+     * Submit spot order
+     */
+⋮----
+/**
+     * Cancel spot order
+     */
+⋮----
+/**
+     * Batch cancel spot order
+     */
+⋮----
+/**
+     * Amend/Update spot order
+     */
+⋮----
+/**
+     * Get spot order status
+     */
+⋮----
+/**
+     * If you don't want to use await (and prefer the async event emitter), make sure to still include a catch block.
+     *
+     * The response will come async via the event emitter in the WS Client.
+     */
+⋮----
+// client
+//   .sendWSAPIRequest('spotV4', 'spot.order_status', {
+//     order_id: '600995435390',
+//     currency_pair: 'BTC_USDT',
+//   })
+//   .catch((e) => {
+//     console.error(`exception ws api call, get spot order status: `, e);
+//   });
+
+================
+File: examples/ws-private-spot.ts
+================
+/* eslint-disable @typescript-eslint/no-unused-vars */
+import { LogParams, WebsocketClient, WsTopicRequest } from '../src/index.js';
+// import { LogParams, WebsocketClient, WsTopicRequest } from 'gateio-api'; // normally you should install this module via npm: `npm install gateio-api`
+⋮----
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+⋮----
+// Define a custom logger object to handle logging at different levels
+⋮----
+// Trace level logging: used for detailed debugging information
+⋮----
+// Uncomment the line below to enable trace logging
+// console.log(new Date(), 'trace', ...params);
+⋮----
+// Info level logging: used for general informational messages
+⋮----
+// Error level logging: used for error messages
+⋮----
+async function start()
+⋮----
+// console.log('auth with: ', account);
+⋮----
+// Data received
+⋮----
+// Something happened, attempting to reconnect
+⋮----
+// Reconnect successful
+⋮----
+// Connection closed. If unexpected, expect reconnect -> reconnected.
+⋮----
+// Reply to a request, e.g. "subscribe"/"unsubscribe"/"authenticate"
+⋮----
+// client.subscribe(topics, 'spotV4');
+⋮----
+// This has the same effect as above, it's just a different way of messaging which topic this is for
+// const topicWithoutParamsAsObject: WsTopicRequest = {
+//   topic: 'spot.balances',
+// };
+⋮----
+/**
+     * Either send one topic (with optional params) at a time
+     */
+// client.subscribe(topicWithoutParamsAsObject, 'spotV4');
+⋮----
+/**
+     * Or send multiple topics in a batch (grouped by ws connection (WsKey))
+     * You can also use strings for topics that don't have any parameters, even if you mix multiple requests into one function call:
+     */
+⋮----
+/**
+     * You can also subscribe in separate function calls as you wish.
+     *
+     * Any duplicate requests should get filtered out (e.g. here we subscribed to "spot.balances" twice, but the WS client will filter this out)
+     */
+
+================
+File: examples/ws-public.ts
+================
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+import { WebsocketClient, WsTopicRequest } from '../src/index.js';
+// import { LogParams, WebsocketClient, WsTopicRequest } from 'gateio-api'; // normally you should install this module via npm: `npm install gateio-api`
+⋮----
+// const customLogger = {
+//   // eslint-disable-next-line @typescript-eslint/no-unused-vars
+//   trace: (...params: LogParams): void => {
+//     console.log('trace', ...params);
+//   },
+//   info: (...params: LogParams): void => {
+//     console.log('info', ...params);
+//   },
+//   error: (...params: LogParams): void => {
+//     console.error('error', ...params);
+//   },
+// };
+⋮----
+async function start()
+⋮----
+// Optional, inject a custom logger
+// const client = new WebsocketClient({}, customLogger);
+⋮----
+// Data received
+⋮----
+// Something happened, attempting to reconnect
+⋮----
+// Reconnect successful
+⋮----
+// Connection closed. If unexpected, expect reconnect -> reconnected.
+⋮----
+// Reply to a request, e.g. "subscribe"/"unsubscribe"/"authenticate"
+⋮----
+// const topicWithoutParamsAsString = 'spot.balances';
+⋮----
+// This has the same effect as above, it's just a different way of messaging which topic this is for
+// const topicWithoutParamsAsObject: WsTopicRequest = {
+//   topic: 'spot.balances',
+// };
+⋮----
+/**
+     * Either send one topic (with optional params) at a time
+     */
+// client.subscribe(tickersRequestWithParams, 'spotV4');
+⋮----
+/**
+     * Or send multiple topics in a batch (grouped by ws connection (WsKey))
+     */
+⋮----
+// /**
+//  * You can also use strings for topics that don't have any parameters, even if you mix multiple requests into one function call:
+//  */
+// client.subscribe(
+//   [tickersRequestWithParams, rawTradesRequestWithParams, topicWithoutParamsAsString],
+//   'spotV4',
+// );
+
+================
+File: src/lib/websocket/websocket-util.ts
+================
+import WebSocket from 'isomorphic-ws';
+⋮----
+import { WSAPIRequest } from '../../types/websockets/requests.js';
+import {
+  FuturesWSAPITopic,
+  SpotWSAPITopic,
+} from '../../types/websockets/wsAPI.js';
+⋮----
+/**
+ * Should be one WS key per unique URL. Some URLs may need a suffix.
+ */
+⋮----
+/**
+   * Spot & Margin
+   * https://www.gate.io/docs/developers/apiv4/ws/en/
+   */
+⋮----
+/**
+   * Perpetual futures (USDT)
+   * https://www.gate.io/docs/developers/futures/ws/en/#gate-io-futures-websocket-v4
+   */
+⋮----
+/**
+   * Perpetual futures (BTC)
+   * https://www.gate.io/docs/developers/futures/ws/en/#gate-io-futures-websocket-v4
+   */
+⋮----
+/**
+   * Delivery Futures (USDT)
+   * https://www.gate.io/docs/developers/delivery/ws/en/
+   */
+⋮----
+/**
+   * Delivery Futures (BTC)
+   * https://www.gate.io/docs/developers/delivery/ws/en/
+   */
+⋮----
+/**
+   * Options
+   * https://www.gate.io/docs/developers/options/ws/en/
+   */
+⋮----
+/**
+   * Announcements V4
+   * https://www.gate.io/docs/developers/options/ws/en/
+   */
+⋮----
+/** This is used to differentiate between each of the available websocket streams */
+export type WsKey = (typeof WS_KEY_MAP)[keyof typeof WS_KEY_MAP];
+⋮----
+export type FuturesWsKey =
+  | typeof WS_KEY_MAP.perpFuturesUSDTV4
+  | typeof WS_KEY_MAP.perpFuturesBTCV4
+  | typeof WS_KEY_MAP.deliveryFuturesUSDTV4
+  | typeof WS_KEY_MAP.deliveryFuturesBTCV4;
+⋮----
+export type WsMarket = 'all';
+⋮----
+/**
+ * Normalised internal format for a request (subscribe/unsubscribe/etc) on a topic, with optional parameters.
+ *
+ * - Topic: the topic this event is for
+ * - Payload: the parameters to include, optional. E.g. auth requires key + sign. Some topics allow configurable parameters.
+ */
+export interface WsTopicRequest<
+  TWSTopic extends string = string,
+  TWSPayload = any,
+> {
+  topic: TWSTopic;
+  payload?: TWSPayload;
+}
+⋮----
+/**
+ * Conveniently allow users to request a topic either as string topics or objects (containing string topic + params)
+ */
+export type WsTopicRequestOrStringTopic<
+  TWSTopic extends string,
+  TWSPayload = any,
+> = WsTopicRequest<TWSTopic, TWSPayload> | string;
+⋮----
+/**
+ * Some exchanges have two livenet environments, some have test environments, some dont. This allows easy flexibility for different exchanges.
+ * Examples:
+ *  - One livenet and one testnet: NetworkMap<'livenet' | 'testnet'>
+ *  - One livenet, sometimes two, one testnet: NetworkMap<'livenet' | 'testnet', 'livenet2'>
+ *  - Only one livenet, no other networks: NetworkMap<'livenet'>
+ */
+type NetworkMap<
+  TRequiredKeys extends string,
+  TOptionalKeys extends string | undefined = undefined,
+> = Record<TRequiredKeys, string> &
+  (TOptionalKeys extends string
+    ? Record<TOptionalKeys, string | undefined>
+    : Record<TRequiredKeys, string>);
+⋮----
+export function neverGuard(x: never, msg: string): Error
+⋮----
+/**
+ * WS API promises are stored using a primary key. This key is constructed using
+ * properties found in every request & reply.
+ */
+export function getPromiseRefForWSAPIRequest(
+  requestEvent: WSAPIRequest,
+): string
+⋮----
+export function getPrivateSpotTopics(): string[]
+⋮----
+// Consumeable channels for spot
+⋮----
+// WebSocket API for spot
+⋮----
+export function getPrivateFuturesTopics(): string[]
+⋮----
+// These are the same for perps vs delivery futures
+⋮----
+export function getPrivateOptionsTopics(): string[]
+⋮----
+/**
+ * ws.terminate() is undefined in browsers.
+ * This only works in node.js, not in browsers.
+ * Does nothing if `ws` is undefined. Does nothing in browsers.
+ */
+export function safeTerminateWs(
+  ws?: WebSocket | any,
+  fallbackToClose?: boolean,
+): boolean
+
+================
+File: src/lib/websocket/WsStore.ts
+================
+import WebSocket from 'isomorphic-ws';
+⋮----
+import { DefaultLogger } from '../logger.js';
+import {
+  DeferredPromise,
+  WSConnectedResult,
+  WsConnectionStateEnum,
+  WsStoredState,
+} from './WsStore.types.js';
+⋮----
+/**
+ * Simple comparison of two objects, only checks 1-level deep (nested objects won't match)
+ */
+export function isDeepObjectMatch(object1: unknown, object2: unknown): boolean
+⋮----
+type DeferredPromiseRef =
+  (typeof DEFERRED_PROMISE_REF)[keyof typeof DEFERRED_PROMISE_REF];
+⋮----
+export class WsStore<
+WsKey extends string,
+⋮----
+constructor(logger: DefaultLogger)
+⋮----
+/** Get WS stored state for key, optionally create if missing */
+get(
+    key: WsKey,
+    createIfMissing?: true,
+  ): WsStoredState<TWSTopicSubscribeEventArgs>;
+⋮----
+get(
+    key: WsKey,
+    createIfMissing?: false,
+  ): WsStoredState<TWSTopicSubscribeEventArgs> | undefined;
+⋮----
+get(
+    key: WsKey,
+    createIfMissing?: boolean,
+): WsStoredState<TWSTopicSubscribeEventArgs> | undefined
+⋮----
+getKeys(): WsKey[]
+⋮----
+create(key: WsKey): WsStoredState<TWSTopicSubscribeEventArgs> | undefined
+⋮----
+delete(key: WsKey): void
+⋮----
+// TODO: should we allow this at all? Perhaps block this from happening...
+⋮----
+/* connection websocket */
+⋮----
+hasExistingActiveConnection(key: WsKey): boolean
+⋮----
+getWs(key: WsKey): WebSocket | undefined
+⋮----
+setWs(key: WsKey, wsConnection: WebSocket): WebSocket
+⋮----
+/**
+   * deferred promises
+   */
+⋮----
+getDeferredPromise<TSuccessResult = any>(
+    wsKey: WsKey,
+    promiseRef: string | DeferredPromiseRef,
+): DeferredPromise<TSuccessResult> | undefined
+⋮----
+createDeferredPromise<TSuccessResult = any>(
+    wsKey: WsKey,
+    promiseRef: string | DeferredPromiseRef,
+    throwIfExists: boolean,
+): DeferredPromise<TSuccessResult>
+⋮----
+// console.log('existing promise');
+⋮----
+// console.log('create promise');
+⋮----
+// TODO: Once stable, use Promise.withResolvers in future
+⋮----
+resolveDeferredPromise(
+    wsKey: WsKey,
+    promiseRef: string | DeferredPromiseRef,
+    value: unknown,
+    removeAfter: boolean,
+): void
+⋮----
+rejectDeferredPromise(
+    wsKey: WsKey,
+    promiseRef: string | DeferredPromiseRef,
+    value: unknown,
+    removeAfter: boolean,
+): void
+⋮----
+removeDeferredPromise(
+    wsKey: WsKey,
+    promiseRef: string | DeferredPromiseRef,
+): void
+⋮----
+// Just in case it's pending
+⋮----
+rejectAllDeferredPromises(wsKey: WsKey, reason: string): void
+⋮----
+// Skip reserved keys, such as the connection promise
+⋮----
+/** Get promise designed to track a connection attempt in progress. Resolves once connected. */
+getConnectionInProgressPromise(
+    wsKey: WsKey,
+): DeferredPromise<WSConnectedResult> | undefined
+⋮----
+getAuthenticationInProgressPromise(
+    wsKey: WsKey,
+): DeferredPromise<WSConnectedResult &
+⋮----
+/**
+   * Create a deferred promise designed to track a connection attempt in progress.
+   *
+   * Will throw if existing promise is found.
+   */
+createConnectionInProgressPromise(
+    wsKey: WsKey,
+    throwIfExists: boolean,
+): DeferredPromise<WSConnectedResult>
+⋮----
+createAuthenticationInProgressPromise(
+    wsKey: WsKey,
+    throwIfExists: boolean,
+): DeferredPromise<WSConnectedResult &
+⋮----
+/** Remove promise designed to track a connection attempt in progress */
+removeConnectingInProgressPromise(wsKey: WsKey): void
+⋮----
+removeAuthenticationInProgressPromise(wsKey: WsKey): void
+⋮----
+/* connection state */
+⋮----
+isWsOpen(key: WsKey): boolean
+⋮----
+getConnectionState(key: WsKey): WsConnectionStateEnum
+⋮----
+setConnectionState(key: WsKey, state: WsConnectionStateEnum)
+⋮----
+isConnectionState(key: WsKey, state: WsConnectionStateEnum): boolean
+⋮----
+/**
+   * Check if we're currently in the process of opening a connection for any reason. Safer than only checking "CONNECTING" as the state
+   * @param key
+   * @returns
+   */
+isConnectionAttemptInProgress(key: WsKey): boolean
+⋮----
+const stateChangeTimeout = 15000; // allow a max 15 second timeout since the last state change before assuming stuck;
+⋮----
+/* subscribed topics */
+⋮----
+getTopics(key: WsKey): Set<TWSTopicSubscribeEventArgs>
+⋮----
+getTopicsByKey(): Record<string, Set<TWSTopicSubscribeEventArgs>>
+⋮----
+/**
+   * Find matching "topic" request from the store
+   * @param key
+   * @param topic
+   * @returns
+   */
+getMatchingTopic(key: WsKey, topic: TWSTopicSubscribeEventArgs)
+⋮----
+addTopic(key: WsKey, topic: TWSTopicSubscribeEventArgs)
+⋮----
+// Check for duplicate topic. If already tracked, don't store this one
+⋮----
+deleteTopic(key: WsKey, topic: TWSTopicSubscribeEventArgs)
+⋮----
+// Check if we're subscribed to a topic like this
+
+================
+File: src/lib/websocket/WsStore.types.ts
+================
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import WebSocket from 'isomorphic-ws';
+⋮----
+export enum WsConnectionStateEnum {
+  INITIAL = 0,
+  CONNECTING = 1,
+  CONNECTED = 2,
+  CLOSING = 3,
+  RECONNECTING = 4,
+  // ERROR_RECONNECTING = 5,
+  ERROR = 5,
+}
+⋮----
+// ERROR_RECONNECTING = 5,
+⋮----
+export interface DeferredPromise<TSuccess = any, TError = any> {
+  resolve?: (value: TSuccess) => TSuccess;
+  reject?: (value: TError) => TError;
+  promise?: Promise<TSuccess>;
+}
+⋮----
+export interface WSConnectedResult {
+  wsKey: string;
+  ws: WebSocket;
+}
+⋮----
+export interface WsStoredState<TWSTopicSubscribeEvent extends string | object> {
+  /** The currently active websocket connection */
+  ws?: WebSocket;
+  /** The current lifecycle state of the connection (enum) */
+  connectionState?: WsConnectionStateEnum;
+  connectionStateChangedAt?: Date;
+  /** A timer that will send an upstream heartbeat (ping) when it expires */
+  activePingTimer?: ReturnType<typeof setTimeout> | undefined;
+  /** A timer tracking that an upstream heartbeat was sent, expecting a reply before it expires */
+  activePongTimer?: ReturnType<typeof setTimeout> | undefined;
+  /** If a reconnection is in progress, this will have the timer for the delayed reconnect */
+  activeReconnectTimer?: ReturnType<typeof setTimeout> | undefined;
+  /**
+   * When a connection attempt is in progress (even for reconnect), a promise is stored here.
+   *
+   * This promise will resolve once connected (and will then get removed);
+   */
+  // connectionInProgressPromise?: DeferredPromise | undefined;
+  deferredPromiseStore: Record<string, DeferredPromise>;
+  /**
+   * All the topics we are expected to be subscribed to on this connection (and we automatically resubscribe to if the connection drops)
+   *
+   * A "Set" and a deep-object-match are used to ensure we only subscribe to a
+   * topic once (tracking a list of unique topics we're expected to be connected to)
+   */
+  subscribedTopics: Set<TWSTopicSubscribeEvent>;
+  /** Whether this connection has completed authentication (only applies to private connections) */
+  isAuthenticated?: boolean;
+  /**
+   * Whether this connection has completed authentication before for the Websocket API, so it k
+   * nows to automatically reauth if reconnected
+   */
+  didAuthWSAPI?: boolean;
+  /** To reauthenticate on the WS API, which channel do we send to? */
+  WSAPIAuthChannel?: string;
+}
+⋮----
+/** The currently active websocket connection */
+⋮----
+/** The current lifecycle state of the connection (enum) */
+⋮----
+/** A timer that will send an upstream heartbeat (ping) when it expires */
+⋮----
+/** A timer tracking that an upstream heartbeat was sent, expecting a reply before it expires */
+⋮----
+/** If a reconnection is in progress, this will have the timer for the delayed reconnect */
+⋮----
+/**
+   * When a connection attempt is in progress (even for reconnect), a promise is stored here.
+   *
+   * This promise will resolve once connected (and will then get removed);
+   */
+// connectionInProgressPromise?: DeferredPromise | undefined;
+⋮----
+/**
+   * All the topics we are expected to be subscribed to on this connection (and we automatically resubscribe to if the connection drops)
+   *
+   * A "Set" and a deep-object-match are used to ensure we only subscribe to a
+   * topic once (tracking a list of unique topics we're expected to be connected to)
+   */
+⋮----
+/** Whether this connection has completed authentication (only applies to private connections) */
+⋮----
+/**
+   * Whether this connection has completed authentication before for the Websocket API, so it k
+   * nows to automatically reauth if reconnected
+   */
+⋮----
+/** To reauthenticate on the WS API, which channel do we send to? */
+
+================
+File: src/lib/BaseRestClient.ts
+================
+import axios, { AxiosRequestConfig, AxiosResponse, Method } from 'axios';
+import https from 'https';
+⋮----
+import { neverGuard } from './misc-util.js';
+import {
+  CHANNEL_ID,
+  getRestBaseUrl,
+  RestClientOptions,
+  serializeParams,
+} from './requestUtils.js';
+import {
+  checkWebCryptoAPISupported,
+  hashMessage,
+  SignAlgorithm,
+  SignEncodeMethod,
+  signMessage,
+} from './webCryptoAPI.js';
+⋮----
+/**
+ * Used to switch how authentication/requests work under the hood
+ */
+⋮----
+export type RestClientType =
+  (typeof REST_CLIENT_TYPE_ENUM)[keyof typeof REST_CLIENT_TYPE_ENUM];
+⋮----
+interface SignedRequest<T extends object | undefined = {}> {
+  originalParams: T;
+  paramsWithSign?: T & { sign: string };
+  serializedParams: string;
+  sign: string;
+  queryParamsWithSign: string;
+  timestamp: number;
+  recvWindow: number;
+}
+⋮----
+interface UnsignedRequest<T extends object | undefined = {}> {
+  originalParams: T;
+  paramsWithSign: T;
+}
+⋮----
+type SignMethod = 'gateV4';
+⋮----
+/**
+ * Some requests require some params to be in the query string and some in the body. Some even support passing params via headers.
+ * This type anticipates these are possible in any combination.
+ *
+ * The request builder will automatically handle where parameters should go.
+ */
+type ParamsInQueryBodyOrHeader = {
+  query?: object;
+  body?: object;
+  headers?: object;
+};
+⋮----
+/**
+ * Enables:
+ * - Detailed request/response logging
+ * - Full request dump in any exceptions thrown from API responses
+ */
+⋮----
+// request: {
+//   url: response.config.url,
+//   method: response.config.method,
+//   data: response.config.data,
+//   headers: response.config.headers,
+// },
+⋮----
+/**
+ * Impure, mutates params to remove any values that have a key but are undefined.
+ */
+function deleteUndefinedValues(params?: any): void
+⋮----
+export abstract class BaseRestClient
+⋮----
+/** Defines the client type (affecting how requests & signatures behave) */
+abstract getClientType(): RestClientType;
+⋮----
+/**
+   * Create an instance of the REST client. Pass API credentials in the object in the first parameter.
+   * @param {RestClientOptions} [restClientOptions={}] options to configure REST API connectivity
+   * @param {AxiosRequestConfig} [networkOptions={}] HTTP networking options for axios
+   */
+constructor(
+    restClientOptions: RestClientOptions = {},
+    networkOptions: AxiosRequestConfig = {},
+)
+⋮----
+/** Throw errors if any request params are empty */
+⋮----
+/** in ms == 5 minutes by default */
+⋮----
+/** inject custom rquest options based on axios specs - see axios docs for more guidance on AxiosRequestConfig: https://github.com/axios/axios#request-config */
+⋮----
+// If enabled, configure a https agent with keepAlive enabled
+⋮----
+// Extract existing https agent parameters, if provided, to prevent the keepAlive flag from overwriting an existing https agent completely
+⋮----
+// For more advanced configuration, raise an issue on GitHub or use the "networkOptions"
+// parameter to define a custom httpsAgent with the desired properties
+⋮----
+// Check Web Crypto API support when credentials are provided and no custom sign function is used
+⋮----
+// Throw if one of the 3 values is missing, but at least one of them is set
+⋮----
+/**
+   * Timestamp used to sign the request. Override this method to implement your own timestamp/sync mechanism
+   */
+getSignTimestampMs(): number
+⋮----
+protected get(endpoint: string, params?: object)
+⋮----
+// GET only supports params in the query string
+⋮----
+protected post(endpoint: string, params?: ParamsInQueryBodyOrHeader)
+⋮----
+protected getPrivate(endpoint: string, params?: object)
+⋮----
+// GET only supports params in the query string
+⋮----
+protected postPrivate(endpoint: string, params?: ParamsInQueryBodyOrHeader)
+⋮----
+protected deletePrivate(
+    endpoint: string,
+    params?: ParamsInQueryBodyOrHeader,
+)
+⋮----
+protected putPrivate(endpoint: string, params?: ParamsInQueryBodyOrHeader)
+⋮----
+// protected patchPrivate(endpoint: string, params?: any) {
+protected patchPrivate(endpoint: string, params?: ParamsInQueryBodyOrHeader)
+⋮----
+/**
+   * @private Make a HTTP request to a specific endpoint. Private endpoint API calls are automatically signed.
+   */
+private async _call(
+    method: Method,
+    endpoint: string,
+    params?: ParamsInQueryBodyOrHeader,
+    isPublicApi?: boolean,
+): Promise<any>
+⋮----
+// Sanity check to make sure it's only ever prefixed by one forward slash
+⋮----
+// Build a request and handle signature process
+⋮----
+// Dispatch request
+⋮----
+// See: https://www.gate.io/docs/developers/apiv4/en/#return-format
+⋮----
+// Throw API rejections by parsing the response code from the body
+⋮----
+/**
+   * @private generic handler to parse request exceptions
+   */
+parseException(e: any, request: AxiosRequestConfig<any>): unknown
+⋮----
+// Something happened in setting up the request that triggered an error
+⋮----
+// request made but no response received
+⋮----
+// The request was made and the server responded with a status code
+// that falls out of the range of 2xx
+⋮----
+// console.error('err: ', response?.data);
+⋮----
+// Prevent credentials from leaking into error messages
+⋮----
+/**
+   * @private sign request and set recv window
+   */
+private async signRequest<
+    T extends ParamsInQueryBodyOrHeader | undefined = {},
+  >(
+    data: T,
+    endpoint: string,
+    method: Method,
+    signMethod: SignMethod,
+): Promise<SignedRequest<T>>
+⋮----
+const timestamp = +(this.getSignTimestampMs() / 1000).toFixed(0); // in seconds
+⋮----
+// recvWindow: this.options.recvWindow,
+⋮----
+// It's possible to override the recv window on a per rquest level
+⋮----
+// console.log('sign params: ', {
+//   requestBodyToHash,
+//   paramsStr: toSign,
+//   url: this.baseUrl,
+//   urlPath: this.baseUrlPath,
+// });
+⋮----
+private async signMessage(
+    paramsStr: string,
+    secret: string,
+    method: 'hex' | 'base64',
+    algorithm: SignAlgorithm,
+): Promise<string>
+⋮----
+private async prepareSignParams<
+    TParams extends ParamsInQueryBodyOrHeader | undefined,
+  >(
+    method: Method,
+    endpoint: string,
+    signMethod: SignMethod,
+    params?: TParams,
+    isPublicApi?: true,
+  ): Promise<UnsignedRequest<TParams>>;
+⋮----
+private async prepareSignParams<
+    TParams extends ParamsInQueryBodyOrHeader | undefined,
+  >(
+    method: Method,
+    endpoint: string,
+    signMethod: SignMethod,
+    params?: TParams,
+    isPublicApi?: false | undefined,
+  ): Promise<SignedRequest<TParams>>;
+⋮----
+private async prepareSignParams<
+    TParams extends ParamsInQueryBodyOrHeader | undefined,
+  >(
+    method: Method,
+    endpoint: string,
+    signMethod: SignMethod,
+    params?: TParams,
+    isPublicApi?: boolean,
+)
+⋮----
+/** Returns an axios request object. Handles signing process automatically if this is a private API call */
+private async buildRequest(
+    method: Method,
+    endpoint: string,
+    url: string,
+    params?: ParamsInQueryBodyOrHeader,
+    isPublicApi?: boolean,
+): Promise<AxiosRequestConfig>
+
+================
+File: src/lib/BaseWSClient.ts
+================
+import EventEmitter from 'events';
+import WebSocket from 'isomorphic-ws';
+⋮----
+import {
+  WebsocketClientOptions,
+  WSClientConfigurableOptions,
+} from '../types/websockets/client.js';
+import { WsOperation } from '../types/websockets/requests.js';
+import { WS_LOGGER_CATEGORY } from '../WebsocketClient.js';
+import { DefaultLogger } from './logger.js';
+import { isMessageEvent, MessageEventLike } from './requestUtils.js';
+import { checkWebCryptoAPISupported } from './webCryptoAPI.js';
+import {
+  safeTerminateWs,
+  WsTopicRequest,
+  WsTopicRequestOrStringTopic,
+} from './websocket/websocket-util.js';
+import { WsStore } from './websocket/WsStore.js';
+import {
+  WSConnectedResult,
+  WsConnectionStateEnum,
+} from './websocket/WsStore.types.js';
+⋮----
+interface WSClientEventMap<WsKey extends string> {
+  /** Connection opened. If this connection was previously opened and reconnected, expect the reconnected event instead */
+  open: (evt: {
+    wsKey: WsKey;
+    event: any;
+    wsUrl: string;
+    ws: WebSocket;
+  }) => void /** Reconnecting a dropped connection */;
+  reconnect: (evt: { wsKey: WsKey; event: any }) => void;
+  /** Successfully reconnected a connection that dropped */
+  reconnected: (evt: {
+    wsKey: WsKey;
+    event: any;
+    wsUrl: string;
+    ws: WebSocket;
+  }) => void;
+  /** Connection closed */
+  close: (evt: { wsKey: WsKey; event: any }) => void;
+  /** Received reply to websocket command (e.g. after subscribing to topics) */
+  response: (response: any & { wsKey: WsKey }) => void;
+  /** Received data for topic */
+  update: (response: any & { wsKey: WsKey }) => void;
+  /** Exception from ws client OR custom listeners (e.g. if you throw inside your event handler) */
+  exception: (response: any & { wsKey: WsKey }) => void;
+  error: (response: any & { wsKey: WsKey }) => void;
+  /** Confirmation that a connection successfully authenticated */
+  authenticated: (event: { wsKey: WsKey; event: any }) => void;
+}
+⋮----
+/** Connection opened. If this connection was previously opened and reconnected, expect the reconnected event instead */
+⋮----
+}) => void /** Reconnecting a dropped connection */;
+⋮----
+/** Successfully reconnected a connection that dropped */
+⋮----
+/** Connection closed */
+⋮----
+/** Received reply to websocket command (e.g. after subscribing to topics) */
+⋮----
+/** Received data for topic */
+⋮----
+/** Exception from ws client OR custom listeners (e.g. if you throw inside your event handler) */
+⋮----
+/** Confirmation that a connection successfully authenticated */
+⋮----
+export interface EmittableEvent<TEvent = any> {
+  eventType: 'response' | 'update' | 'exception' | 'authenticated';
+  event: TEvent;
+}
+⋮----
+// Type safety for on and emit handlers: https://stackoverflow.com/a/61609010/880837
+export interface BaseWebsocketClient<TWSKey extends string> {
+  on<U extends keyof WSClientEventMap<TWSKey>>(
+    event: U,
+    listener: WSClientEventMap<TWSKey>[U],
+  ): this;
+
+  emit<U extends keyof WSClientEventMap<TWSKey>>(
+    event: U,
+    ...args: Parameters<WSClientEventMap<TWSKey>[U]>
+  ): boolean;
+}
+⋮----
+on<U extends keyof WSClientEventMap<TWSKey>>(
+    event: U,
+    listener: WSClientEventMap<TWSKey>[U],
+  ): this;
+⋮----
+emit<U extends keyof WSClientEventMap<TWSKey>>(
+    event: U,
+    ...args: Parameters<WSClientEventMap<TWSKey>[U]>
+  ): boolean;
+⋮----
+/**
+ * Users can conveniently pass topics as strings or objects (object has topic name + optional params).
+ *
+ * This method normalises topics into objects (object has topic name + optional params).
+ */
+function getNormalisedTopicRequests(
+  wsTopicRequests: WsTopicRequestOrStringTopic<string>[],
+): WsTopicRequest<string>[]
+⋮----
+// passed as string, convert to object
+⋮----
+// already a normalised object, thanks to user
+⋮----
+/**
+ * Base WebSocket abstraction layer. Handles connections, tracking each connection as a unique "WS Key"
+ */
+// eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
+export abstract class BaseWebsocketClient<
+⋮----
+/**
+   * The WS connections supported by the client, each identified by a unique primary key
+   */
+⋮----
+/**
+   * State store to track a list of topics (topic requests) we are expected to be subscribed to if reconnected
+   */
+⋮----
+constructor(
+    options?: WSClientConfigurableOptions,
+    logger?: typeof DefaultLogger,
+)
+⋮----
+// Some defaults:
+⋮----
+// Gate.io only has one connection (for both public & private). Auth works with every sub, not on connect, so this is turned off.
+⋮----
+// Gate.io requires auth to be added to every request, when subscribing to private topics. This is handled automatically.
+⋮----
+// Automatically re-auth WS API, if we were auth'd before and get reconnected
+⋮----
+// Check Web Crypto API support when credentials are provided and no custom sign function is used
+⋮----
+protected abstract isAuthOnConnectWsKey(wsKey: TWSKey): boolean;
+⋮----
+protected abstract sendPingEvent(wsKey: TWSKey, ws: WebSocket): void;
+⋮----
+protected abstract sendPongEvent(wsKey: TWSKey, ws: WebSocket): void;
+⋮----
+protected abstract isWsPing(data: any): boolean;
+⋮----
+protected abstract isWsPong(data: any): boolean;
+⋮----
+protected abstract getWsAuthRequestEvent(wsKey: TWSKey): Promise<object>;
+⋮----
+protected abstract isPrivateTopicRequest(
+    request: WsTopicRequest<string>,
+    wsKey: TWSKey,
+  ): boolean;
+⋮----
+protected abstract getPrivateWSKeys(): TWSKey[];
+⋮----
+protected abstract getWsUrl(wsKey: TWSKey): string;
+⋮----
+protected abstract getMaxTopicsPerSubscribeEvent(
+    wsKey: TWSKey,
+  ): number | null;
+⋮----
+/**
+   * Returns a list of string events that can be individually sent upstream to complete subscribing/unsubscribing/etc to these topics
+   */
+protected abstract getWsOperationEventsForTopics(
+    topics: WsTopicRequest<string>[],
+    wsKey: TWSKey,
+    operation: WsOperation,
+  ): Promise<string[]>;
+⋮----
+/**
+   * Abstraction called to sort ws events into emittable event types (response to a request, data update, etc)
+   */
+protected abstract resolveEmittableEvents(
+    wsKey: TWSKey,
+    event: MessageEventLike,
+  ): EmittableEvent[];
+⋮----
+/**
+   * Request connection of all dependent (public & private) websockets, instead of waiting for automatic connection by library
+   */
+protected abstract connectAll(): Promise<WSConnectedResult | undefined>[];
+⋮----
+protected isPrivateWsKey(wsKey: TWSKey): boolean
+⋮----
+/** Returns auto-incrementing request ID, used to track promise references for async requests */
+protected getNewRequestId(): string
+⋮----
+protected abstract sendWSAPIRequest(
+    wsKey: TWSKey,
+    channel: string,
+    params?: any,
+  ): Promise<unknown>;
+⋮----
+protected abstract sendWSAPIRequest(
+    wsKey: TWSKey,
+    channel: string,
+    params: any,
+  ): Promise<unknown>;
+⋮----
+public getTimeOffsetMs()
+⋮----
+// TODO: not implemented
+public setTimeOffsetMs(newOffset: number)
+⋮----
+/**
+   * Don't call directly! Use subscribe() instead!
+   *
+   * Subscribe to one or more topics on a WS connection (identified by WS Key).
+   *
+   * - Topics are automatically cached
+   * - Connections are automatically opened, if not yet connected
+   * - Authentication is automatically handled
+   * - Topics are automatically resubscribed to, if something happens to the connection, unless you call unsubsribeTopicsForWsKey(topics, key).
+   *
+   * @param wsRequests array of topics to subscribe to
+   * @param wsKey ws key referring to the ws connection these topics should be subscribed on
+   */
+protected subscribeTopicsForWsKey(
+    wsTopicRequests: WsTopicRequestOrStringTopic<string>[],
+    wsKey: TWSKey,
+)
+⋮----
+// Store topics, so future automation (post-auth, post-reconnect) has everything needed to resubscribe automatically
+⋮----
+// start connection process if it hasn't yet begun. Topics are automatically subscribed to on-connect
+⋮----
+// Subscribe should happen automatically once connected, nothing to do here after topics are added to wsStore.
+⋮----
+/**
+       * Are we in the process of connection? Nothing to send yet.
+       */
+⋮----
+// We're connected. Check if auth is needed and if already authenticated
+⋮----
+/**
+       * If not authenticated yet and auth is required, don't request topics yet.
+       *
+       * Auth should already automatically be in progress, so no action needed from here. Topics will automatically subscribe post-auth success.
+       */
+⋮----
+// Finally, request subscription to topics if the connection is healthy and ready
+⋮----
+protected unsubscribeTopicsForWsKey(
+    wsTopicRequests: WsTopicRequestOrStringTopic<string>[],
+    wsKey: TWSKey,
+)
+⋮----
+// Store topics, so future automation (post-auth, post-reconnect) has everything needed to resubscribe automatically
+⋮----
+// If not connected, don't need to do anything.
+// Removing the topic from the store is enough to stop it from being resubscribed to on reconnect.
+⋮----
+// We're connected. Check if auth is needed and if already authenticated
+⋮----
+/**
+       * If not authenticated yet and auth is required, don't need to do anything.
+       * We don't subscribe to topics until auth is complete anyway.
+       */
+⋮----
+// Finally, request subscription to topics if the connection is healthy and ready
+⋮----
+/**
+   * Splits topic requests into two groups, public & private topic requests
+   */
+private sortTopicRequestsIntoPublicPrivate(
+    wsTopicRequests: WsTopicRequest<string>[],
+    wsKey: TWSKey,
+):
+⋮----
+/** Get the WsStore that tracks websockets & topics */
+public getWsStore(): WsStore<TWSKey, WsTopicRequest<string>>
+⋮----
+public close(wsKey: TWSKey, force?: boolean)
+⋮----
+public closeAll(force?: boolean)
+⋮----
+public isConnected(wsKey: TWSKey): boolean
+⋮----
+/**
+   * Request connection to a specific websocket, instead of waiting for automatic connection.
+   */
+protected async connect(
+    wsKey: TWSKey,
+): Promise<WSConnectedResult | undefined>
+⋮----
+private connectToWsUrl(url: string, wsKey: TWSKey): WebSocket
+⋮----
+private parseWsError(context: string, error: any, wsKey: TWSKey)
+⋮----
+/** Get a signature, build the auth request and send it */
+private async sendAuthRequest(wsKey: TWSKey): Promise<unknown>
+⋮----
+// console.log('ws auth req', request);
+⋮----
+private reconnectWithDelay(wsKey: TWSKey, connectionDelayMs: number)
+⋮----
+private ping(wsKey: TWSKey)
+⋮----
+private clearTimers(wsKey: TWSKey)
+⋮----
+// Send a ping at intervals
+private clearPingTimer(wsKey: TWSKey)
+⋮----
+// Expect a pong within a time limit
+private clearPongTimer(wsKey: TWSKey)
+⋮----
+// this.logger.trace(`Cleared pong timeout for "${wsKey}"`);
+⋮----
+// this.logger.trace(`No active pong timer for "${wsKey}"`);
+⋮----
+/**
+   * Simply builds and sends subscribe events for a list of topics for a ws key
+   *
+   * @private Use the `subscribe(topics)` or `subscribeTopicsForWsKey(topics, wsKey)` method to subscribe to topics. Send WS message to subscribe to topics.
+   */
+private async requestSubscribeTopics(
+    wsKey: TWSKey,
+    topics: WsTopicRequest<string>[],
+)
+⋮----
+// Automatically splits requests into smaller batches, if needed
+⋮----
+`Subscribing to ${topics.length} "${wsKey}" topics in ${subscribeWsMessages.length} batches.`, // Events: "${JSON.stringify(topics)}"
+⋮----
+// console.log(`batches: `, JSON.stringify(subscribeWsMessages, null, 2));
+⋮----
+// this.logger.trace(`Sending batch via message: "${wsMessage}"`);
+⋮----
+/**
+   * Simply builds and sends unsubscribe events for a list of topics for a ws key
+   *
+   * @private Use the `unsubscribe(topics)` method to unsubscribe from topics. Send WS message to unsubscribe from topics.
+   */
+private async requestUnsubscribeTopics(
+    wsKey: TWSKey,
+    wsTopicRequests: WsTopicRequest<string>[],
+)
+⋮----
+/**
+   * Try sending a string event on a WS connection (identified by the WS Key)
+   */
+public tryWsSend(
+    wsKey: TWSKey,
+    wsMessage: string,
+    throwExceptions?: boolean,
+)
+⋮----
+private async onWsOpen(
+    event: any,
+    wsKey: TWSKey,
+    url: string,
+    ws: WebSocket,
+)
+⋮----
+// Resolve & cleanup deferred "connection attempt in progress" promise
+⋮----
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+⋮----
+// Remove before resolving, in case there's more requests queued
+⋮----
+// Some websockets require an auth packet to be sent after opening the connection
+⋮----
+// Reconnect to topics known before it connected
+⋮----
+// Request sub to public topics, if any
+⋮----
+// Request sub to private topics, if auth on connect isn't needed
+⋮----
+// If enabled, automatically reauth WS API if reconnected
+⋮----
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+⋮----
+/**
+   * Handle subscription to private topics _after_ authentication successfully completes asynchronously.
+   *
+   * Only used for exchanges that require auth before sending private topic subscription requests
+   */
+private onWsAuthenticated(
+    wsKey: TWSKey,
+    event: { isWSAPI?: boolean; WSAPIAuthChannel?: string },
+)
+⋮----
+// Resolve & cleanup deferred "auth attempt in progress" promise
+⋮----
+// Remove before continuing, in case there's more requests queued
+⋮----
+private onWsMessage(event: unknown, wsKey: TWSKey, ws: WebSocket)
+⋮----
+// any message can clear the pong timer - wouldn't get a message if the ws wasn't working
+⋮----
+// console.log(`raw event: `, { data, dataType, emittableEvents });
+⋮----
+private onWsClose(event: unknown, wsKey: TWSKey)
+⋮----
+// unintentional close, attempt recovery
+⋮----
+// clean up any pending promises for this connection
+⋮----
+// intentional close - clean up
+// clean up any pending promises for this connection
+⋮----
+// clean up any pending promises for this connection
+⋮----
+// This was an intentional close, delete all state for this connection, as if it never existed:
+⋮----
+private getWs(wsKey: TWSKey)
+⋮----
+private setWsState(wsKey: TWSKey, state: WsConnectionStateEnum)
+⋮----
+/**
+   * Promise-driven method to assert that a ws has successfully connected (will await until connection is open)
+   */
+protected async assertIsConnected(wsKey: TWSKey): Promise<unknown>
+⋮----
+// Already in progress? Await shared promise and retry
+⋮----
+// Start connection, it should automatically store/return a promise.
+⋮----
+/**
+   * Promise-driven method to assert that a ws has been successfully authenticated (will await until auth is confirmed)
+   */
+public async assertIsAuthenticated(wsKey: TWSKey): Promise<unknown>
+⋮----
+// Already in progress? Await shared promise and retry
+⋮----
+// this.logger.trace('assertIsAuthenticated(): ok');
+⋮----
+// Start authentication, it should automatically store/return a promise.
+
+================
+File: src/lib/logger.ts
+================
+export type LogParams = null | any;
+⋮----
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+⋮----
+// console.log(_params);
+⋮----
+export type DefaultLogger = typeof DefaultLogger;
+
+================
 File: src/lib/misc-util.ts
 ================
 export function neverGuard(x: never, msg: string): Error
+
+================
+File: src/lib/requestUtils.ts
+================
+import WebSocket from 'isomorphic-ws';
+⋮----
+import { GateBaseUrlKey } from '../types/shared.js';
+⋮----
+export interface RestClientOptions {
+  /** Your API key */
+  apiKey?: string;
+
+  /** Your API secret */
+  apiSecret?: string;
+
+  /**
+   * Override the default/global max size of the request window (in ms) for signed api calls.
+   * If you don't include a recv window when making an API call, this value will be used as default
+   */
+  recvWindow?: number;
+
+  /** Default: false. If true, we'll throw errors if any params are undefined */
+  strictParamValidation?: boolean;
+
+  /**
+   * Optionally override API protocol + domain
+   * e.g baseUrl: 'https://api.gate.io'
+   **/
+  baseUrl?: string;
+
+  // manually override with one of the known base URLs in the library
+  baseUrlKey?: GateBaseUrlKey;
+
+  /** Default: true. whether to try and post-process request exceptions (and throw them). */
+  parseExceptions?: boolean;
+
+  /**
+   * Enable keep alive for REST API requests (via axios).
+   * See: https://github.com/tiagosiebler/bybit-api/issues/368
+   */
+  keepAlive?: boolean;
+
+  /**
+   * When using HTTP KeepAlive, how often to send TCP KeepAlive packets over sockets being kept alive. Default = 1000.
+   * Only relevant if keepAlive is set to true.
+   * Default: 1000 (defaults comes from https agent)
+   */
+  keepAliveMsecs?: number;
+
+  /**
+   * Allows you to provide a custom "signMessage" function, e.g. to use node's much faster createHmac method
+   *
+   * Look in the examples folder for a demonstration on using node's createHmac instead.
+   */
+  customSignMessageFn?: (message: string, secret: string) => Promise<string>;
+}
+⋮----
+/** Your API key */
+⋮----
+/** Your API secret */
+⋮----
+/**
+   * Override the default/global max size of the request window (in ms) for signed api calls.
+   * If you don't include a recv window when making an API call, this value will be used as default
+   */
+⋮----
+/** Default: false. If true, we'll throw errors if any params are undefined */
+⋮----
+/**
+   * Optionally override API protocol + domain
+   * e.g baseUrl: 'https://api.gate.io'
+   **/
+⋮----
+// manually override with one of the known base URLs in the library
+⋮----
+/** Default: true. whether to try and post-process request exceptions (and throw them). */
+⋮----
+/**
+   * Enable keep alive for REST API requests (via axios).
+   * See: https://github.com/tiagosiebler/bybit-api/issues/368
+   */
+⋮----
+/**
+   * When using HTTP KeepAlive, how often to send TCP KeepAlive packets over sockets being kept alive. Default = 1000.
+   * Only relevant if keepAlive is set to true.
+   * Default: 1000 (defaults comes from https agent)
+   */
+⋮----
+/**
+   * Allows you to provide a custom "signMessage" function, e.g. to use node's much faster createHmac method
+   *
+   * Look in the examples folder for a demonstration on using node's createHmac instead.
+   */
+⋮----
+export function serializeParams<T extends Record<string, any> | undefined = {}>(
+  params: T,
+  strict_validation: boolean | undefined,
+  encodeValues: boolean,
+  prefixWith: string,
+): string
+⋮----
+// Only prefix if there's a value
+⋮----
+export function getRestBaseUrl(restClientOptions: RestClientOptions): string
+⋮----
+export interface MessageEventLike {
+  target: WebSocket;
+  type: 'message';
+  data: string;
+}
+⋮----
+export function isMessageEvent(msg: unknown): msg is MessageEventLike
+
+================
+File: src/lib/webCryptoAPI.ts
+================
+import { neverGuard } from './misc-util.js';
+⋮----
+function bufferToB64(buffer: ArrayBuffer): string
+⋮----
+export type SignEncodeMethod = 'hex' | 'base64';
+export type SignAlgorithm = 'SHA-256' | 'SHA-512';
+⋮----
+/**
+ * Similar to node crypto's `createHash()` function
+ */
+export async function hashMessage(
+  message: string,
+  method: SignEncodeMethod,
+  algorithm: SignAlgorithm,
+): Promise<string>
+⋮----
+/**
+ * Sign a message, with a secret, using the Web Crypto API
+ */
+export async function signMessage(
+  message: string,
+  secret: string,
+  method: SignEncodeMethod,
+  algorithm: SignAlgorithm,
+): Promise<string>
+⋮----
+export function checkWebCryptoAPISupported()
 
 ================
 File: src/types/request/account.ts
@@ -846,6 +2572,296 @@ export interface SubmitFlashSwapOrderPreviewReq {
   buy_currency: string;
   buy_amount?: string;
 }
+
+================
+File: src/types/request/futures.ts
+================
+/**==========================================================================================================================
+ * FUTURES
+ * ==========================================================================================================================
+ */
+⋮----
+export interface GetFuturesOrderBookReq {
+  settle: 'btc' | 'usdt' | 'usd';
+  contract: string;
+  interval?: string;
+  limit?: number;
+  with_id?: boolean;
+}
+⋮----
+export interface GetFuturesTradesReq {
+  settle: 'btc' | 'usdt' | 'usd';
+  contract: string;
+  limit?: number;
+  offset?: number;
+  last_id?: string;
+  from?: number;
+  to?: number;
+}
+⋮----
+export interface GetFuturesCandlesReq {
+  settle: 'btc' | 'usdt' | 'usd';
+  contract: string;
+  from?: number;
+  to?: number;
+  limit?: number;
+  interval?: string;
+}
+⋮----
+export interface GetFuturesStatsReq {
+  settle: 'btc' | 'usdt' | 'usd';
+  contract: string;
+  from?: number;
+  interval?: string;
+  limit?: number;
+}
+⋮----
+export interface GetFundingRatesReq {
+  settle: 'btc' | 'usdt' | 'usd';
+  contract: string;
+  limit?: number;
+  from?: number;
+  to?: number;
+}
+⋮----
+export interface GetLiquidationHistoryReq {
+  settle: 'btc' | 'usdt' | 'usd';
+  contract?: string;
+  from?: number;
+  to?: number;
+  limit?: number;
+}
+⋮----
+export interface GetRiskLimitTiersReq {
+  settle: 'btc' | 'usdt' | 'usd';
+  contract: string;
+  limit?: number;
+  offset?: number;
+}
+⋮----
+export interface GetRiskLimitTableReq {
+  settle: 'btc' | 'usdt' | 'usd';
+  table_id: string;
+}
+⋮----
+export interface GetFuturesAccountBookReq {
+  settle: 'btc' | 'usdt' | 'usd';
+  contract?: string;
+  limit?: number;
+  offset?: number;
+  from?: number;
+  to?: number;
+  type?:
+    | 'dnw'
+    | 'pnl'
+    | 'fee'
+    | 'refr'
+    | 'fund'
+    | 'point_dnw'
+    | 'point_fee'
+    | 'point_refr'
+    | 'bonus_offset';
+}
+⋮----
+export interface GetFuturesPositionsReq {
+  settle: 'btc' | 'usdt' | 'usd';
+  holding?: boolean;
+  limit?: number;
+  offset?: number;
+  position_side?: string; // v4.105.3: Add position_side parameter for hedge mode support
+  hedge_mode?: boolean; // v4.104.3: Add hedge_mode parameter
+}
+⋮----
+position_side?: string; // v4.105.3: Add position_side parameter for hedge mode support
+hedge_mode?: boolean; // v4.104.3: Add hedge_mode parameter
+⋮----
+export interface UpdateDualModePositionMarginReq {
+  settle: 'btc' | 'usdt' | 'usd';
+  contract: string;
+  change: string;
+  dual_side: 'dual_long' | 'dual_short';
+}
+⋮----
+export interface UpdateDualModePositionLeverageReq {
+  settle: 'btc' | 'usdt' | 'usd';
+  contract: string;
+  leverage: string;
+  cross_leverage_limit?: string;
+}
+⋮----
+export interface SubmitFuturesOrderReq {
+  xGateExptime?: number;
+  settle: 'btc' | 'usdt' | 'usd';
+  contract: string;
+  size: number;
+  iceberg?: number;
+  price?: string;
+  close?: boolean;
+  reduce_only?: boolean;
+  tif?: string;
+  text?: string;
+  auto_size?: string;
+  stp_act?: string;
+}
+⋮----
+export interface GetFuturesOrdersReq {
+  settle: 'btc' | 'usdt' | 'usd';
+  contract?: string;
+  status: string;
+  limit?: number;
+  offset?: number;
+  last_id?: string;
+}
+⋮----
+export interface DeleteAllFuturesOrdersReq {
+  xGateExptime?: number;
+  settle: 'btc' | 'usdt' | 'usd';
+  contract: string;
+  side?: string;
+}
+⋮----
+export interface GetFuturesOrdersByTimeRangeReq {
+  settle: 'btc' | 'usdt' | 'usd';
+  contract?: string;
+  from?: number;
+  to?: number;
+  limit?: number;
+  offset?: number;
+}
+⋮----
+export interface UpdateFuturesOrderReq {
+  xGateExptime?: number;
+  settle: 'btc' | 'usdt' | 'usd';
+  order_id: string;
+  size?: number;
+  price?: string;
+  amend_text?: string;
+}
+⋮----
+export interface GetFuturesTradingHistoryReq {
+  settle: 'btc' | 'usdt' | 'usd';
+  contract?: string;
+  order?: number;
+  limit?: number;
+  offset?: number;
+  last_id?: string;
+}
+⋮----
+export interface GetFuturesTradingHistoryByTimeRangeReq {
+  settle: 'btc' | 'usdt' | 'usd';
+  contract?: string;
+  from?: number;
+  to?: number;
+  limit?: number;
+  offset?: number;
+  role?: 'maker' | 'taker';
+}
+⋮----
+export interface GetFuturesPositionHistoryReq {
+  settle: 'btc' | 'usdt' | 'usd';
+  contract?: string;
+  limit?: number;
+  offset?: number;
+  from?: number;
+  to?: number;
+  side?: 'long' | 'short';
+  pnl?: string;
+}
+⋮----
+export interface GetFuturesLiquidationHistoryReq {
+  settle: 'btc' | 'usdt' | 'usd';
+  contract?: string;
+  limit?: number;
+  at?: number;
+}
+⋮----
+export interface SubmitFuturesTriggeredOrderReq {
+  initial: {
+    contract: string;
+    size?: number;
+    price: string; // Required: Order price. Set to 0 to use market price
+    close?: boolean;
+    tif?: 'gtc' | 'ioc';
+    text?: string;
+    reduce_only?: boolean;
+    auto_size?: string;
+  };
+  trigger: {
+    strategy_type?: 0 | 1;
+    price_type?: 0 | 1 | 2;
+    price: string; // Required: Price value for price trigger
+    rule: 1 | 2; // Required: Price Condition Type (1: >=, 2: <=)
+    expiration?: number;
+  };
+  order_type?:
+    | 'close-long-order'
+    | 'close-short-order'
+    | 'close-long-position'
+    | 'close-short-position'
+    | 'plan-close-long-position'
+    | 'plan-close-short-position';
+  settle: 'btc' | 'usdt' | 'usd';
+}
+⋮----
+price: string; // Required: Order price. Set to 0 to use market price
+⋮----
+price: string; // Required: Price value for price trigger
+rule: 1 | 2; // Required: Price Condition Type (1: >=, 2: <=)
+⋮----
+export interface GetFuturesAutoOrdersReq {
+  settle: 'btc' | 'usdt' | 'usd';
+  status: 'open' | 'finished';
+  contract?: string;
+  limit?: number;
+  offset?: number;
+}
+⋮----
+/**
+ * Modify contract order parameters
+ */
+export interface BatchAmendOrderReq {
+  order_id?: number; // Order id, order_id and text must contain at least one
+  text?: string; // User-defined order text, at least one of order_id and text must be passed
+  size?: number; // The new order size, including the executed order size
+  price?: string; // New order price
+  amend_text?: string; // Custom info during amending order
+}
+⋮----
+order_id?: number; // Order id, order_id and text must contain at least one
+text?: string; // User-defined order text, at least one of order_id and text must be passed
+size?: number; // The new order size, including the executed order size
+price?: string; // New order price
+amend_text?: string; // Custom info during amending order
+⋮----
+// v4.105.8: New GET /futures/{settle}/position_close_history endpoint request
+export interface GetFuturesPositionCloseHistoryReq {
+  settle: 'btc' | 'usdt' | 'usd';
+  contract?: string;
+  limit?: number;
+  offset?: number;
+  from?: number;
+  to?: number;
+}
+⋮----
+// v4.104.6: New GET /futures/{settle}/insurance endpoint request
+export interface GetFuturesInsuranceReq {
+  settle: 'btc' | 'usdt' | 'usd';
+  limit?: number;
+}
+⋮----
+export interface UpdateFuturesPriceTriggeredOrderReq {
+  settle: 'btc' | 'usdt' | 'usd';
+  order_id: string;
+  contract?: string;
+  size?: number;
+  price?: string;
+  trigger_price?: string;
+  price_type?: 0 | 1 | 2; // 0 - Latest trade price, 1 - Mark price, 2 - Index price
+  auto_size?: string; // Not required in single position mode
+}
+⋮----
+price_type?: 0 | 1 | 2; // 0 - Latest trade price, 1 - Mark price, 2 - Index price
+auto_size?: string; // Not required in single position mode
 
 ================
 File: src/types/request/margin.ts
@@ -1165,6 +3181,167 @@ export interface PartnerTransactionReq {
 }
 
 ================
+File: src/types/request/spot.ts
+================
+/**==========================================================================================================================
+ * SPOT
+ * ==========================================================================================================================
+ */
+⋮----
+export interface GetSpotOrderBookReq {
+  currency_pair: string;
+  interval?: string;
+  limit?: number;
+  with_id?: boolean;
+}
+⋮----
+export interface GetSpotTradesReq {
+  currency_pair: string;
+  limit?: number;
+  last_id?: string;
+  reverse?: boolean;
+  from?: number;
+  to?: number;
+  page?: number;
+}
+⋮----
+export interface GetSpotCandlesReq {
+  currency_pair: string;
+  limit?: number;
+  from?: number;
+  to?: number;
+  interval?:
+    | '1s'
+    | '10s'
+    | '1m'
+    | '5m'
+    | '15m'
+    | '30m'
+    | '1h'
+    | '4h'
+    | '8h'
+    | '1d'
+    | '7d'
+    | '30d';
+}
+⋮----
+export interface GetSpotAccountBookReq {
+  currency?: string;
+  from?: number;
+  to?: number;
+  page?: number;
+  limit?: number;
+  type?: string;
+  code?: string;
+}
+⋮----
+export interface SubmitSpotClosePosCrossDisabledReq {
+  text?: string;
+  currency_pair: string;
+  amount: string;
+  price: string;
+  action_mode?: 'ACK' | 'RESULT' | 'FULL';
+}
+⋮----
+export interface GetSpotOrdersReq {
+  currency_pair: string;
+  status: 'open' | 'finished';
+  page?: number;
+  limit?: number;
+  account?: 'spot' | 'margin' | 'cross_margin' | 'unified';
+  from?: number;
+  to?: number;
+  side?: 'buy' | 'sell';
+}
+⋮----
+export interface CancelSpotBatchOrdersReq {
+  currency_pair: string;
+  id: string;
+  account?: 'cross_margin';
+  action_mode?: 'ACK' | 'RESULT' | 'FULL';
+}
+⋮----
+export interface DeleteSpotOrderReq {
+  order_id: string;
+  currency_pair: string;
+  account?: 'spot' | 'margin' | 'cross_margin' | 'unified';
+  action_mode?: 'ACK' | 'RESULT' | 'FULL';
+  xGateExptime?: number;
+}
+⋮----
+export interface GetSpotOrderReq {
+  order_id: string;
+  currency_pair: string;
+  account?: 'spot' | 'margin' | 'cross_margin' | 'unified';
+}
+⋮----
+export interface GetSpotTradingHistoryReq {
+  currency_pair?: string;
+  limit?: number;
+  page?: number;
+  order_id?: string;
+  account?: 'spot' | 'margin' | 'cross_margin' | 'unified';
+  from?: number;
+  to?: number;
+}
+⋮----
+export interface UpdateSpotBatchOrdersReq {
+  order_id?: string;
+  currency_pair?: string;
+  amount?: string;
+  price?: string;
+  amend_text?: string;
+}
+⋮----
+export interface GetSpotInsuranceHistoryReq {
+  business: 'margin' | 'unified';
+  currency: string;
+  from: number;
+  to: number;
+  page?: number;
+  limit?: number;
+}
+⋮----
+export interface GetSpotAutoOrdersReq {
+  status: 'open' | 'finished';
+  market?: string;
+  account?: 'normal' | 'margin' | 'cross_margin' | 'unified';
+  limit?: number;
+  offset?: number;
+}
+⋮----
+export interface SubmitSpotOrderReq {
+  xGateExptime?: number;
+  side: 'buy' | 'sell';
+  amount: string;
+  text?: string;
+  currency_pair: string;
+  type?: 'limit' | 'market';
+  account?: 'spot' | 'margin' | 'cross_margin' | 'unified';
+  price?: string;
+  time_in_force?: 'gtc' | 'ioc' | 'poc' | 'fok';
+  iceberg?: string;
+  auto_borrow?: boolean;
+  auto_repay?: boolean;
+  stp_act?: string;
+  action_mode?: string;
+  stop_loss?: string;
+  take_profit?: string;
+  post_only?: boolean;
+}
+⋮----
+export interface UpdateSpotOrderReq {
+  xGateExptime?: number;
+  order_id: string;
+  currency_pair: string;
+  account?: 'spot' | 'margin' | 'cross_margin' | 'unified';
+  amount?: string;
+  price?: string;
+  amend_text?: string;
+  action_mode?: 'ACK' | 'RESULT' | 'FULL';
+}
+
+================
 File: src/types/request/subaccount.ts
 ================
 export interface CreateSubAccountReq {
@@ -1205,2419 +3382,6 @@ ip_whitelist?: string[]; // IP white list
 export type UpdateSubAccountApiKeyReq = {
   key: string;
 } & CreateSubAccountApiKeyReq;
-
-================
-File: src/types/request/withdrawal.ts
-================
-/**================================================================================================================================
- * WITHDRAW
- * ==========================================================================================================================
- */
-⋮----
-export interface SubmitWithdrawalReq {
-  amount: string;
-  currency: string;
-  chain: string;
-  withdraw_order_id?: string;
-  address?: string;
-  memo?: string;
-}
-
-================
-File: src/types/response/account.ts
-================
-/**==========================================================================================================================
- * ACCOUNT
- * ==========================================================================================================================
- */
-⋮----
-export interface AccountDetail {
-  user_id: number;
-  ip_whitelist: string[];
-  currency_pairs: string[];
-  key: {
-    mode: number;
-  };
-  tier: number;
-  copy_trading_role: number;
-}
-⋮----
-export interface AccountRateLimit {
-  type: string;
-  tier: string;
-  ratio: string;
-  main_ratio: string;
-  updated_at: string;
-}
-⋮----
-export interface StpGroup {
-  id: number;
-  name: string;
-  creator_id: number;
-  create_time: number;
-}
-⋮----
-export interface StpGroupUser {
-  user_id: number;
-  stp_id: number;
-  create_time: number;
-}
-
-================
-File: src/types/response/collateralloan.ts
-================
-/**==========================================================================================================================
- * COLLATERAL LOAN
- * ==========================================================================================================================
- */
-⋮----
-export interface LoanOrder {
-  order_id: number;
-  collateral_currency: string;
-  collateral_amount: string;
-  borrow_currency: string;
-  borrow_amount: string;
-  repaid_amount: string;
-  repaid_principal: string;
-  repaid_interest: string;
-  init_ltv: string;
-  current_ltv: string;
-  liquidate_ltv: string;
-  status: string;
-  borrow_time: number;
-  left_repay_total: string;
-  left_repay_principal: string;
-  left_repay_interest: string;
-}
-⋮----
-export interface LoanRepaymentHistoryRecord {
-  order_id: number;
-  record_id: number;
-  repaid_amount: string;
-  borrow_currency: string;
-  collateral_currency: string;
-  init_ltv: string;
-  borrow_time: number;
-  repay_time: number;
-  total_interest: string;
-  before_left_principal: string;
-  after_left_principal: string;
-  before_left_collateral: string;
-  after_left_collateral: string;
-}
-⋮----
-export interface LoanCollateralRecord {
-  order_id: number;
-  record_id: number;
-  borrow_currency: string;
-  borrow_amount: string;
-  collateral_currency: string;
-  before_collateral: string;
-  after_collateral: string;
-  before_ltv: string;
-  after_ltv: string;
-  operate_time: number;
-}
-⋮----
-export interface LoanCollateralRatio {
-  collateral_currency: string;
-  borrow_currency: string;
-  init_ltv: string;
-  alert_ltv: string;
-  liquidate_ltv: string;
-  min_borrow_amount: string;
-  left_borrowable_amount: string;
-}
-
-================
-File: src/types/response/earnuni.ts
-================
-/**==========================================================================================================================
- * EARN UNI
- * ==========================================================================================================================
- */
-⋮----
-export interface LendingCurrency {
-  currency: string;
-  min_lend_amount: string;
-  max_lend_amount: string;
-  max_rate: string;
-  min_rate: string;
-}
-⋮----
-export interface LendingOrder {
-  currency: string;
-  current_amount: string;
-  amount: string;
-  lent_amount: string;
-  frozen_amount: string;
-  min_rate: string;
-  interest_status: string;
-  reinvest_left_amount: string;
-  create_time: number;
-  update_time: number;
-}
-⋮----
-export interface LendingRecord {
-  currency: string;
-  amount: string;
-  last_wallet_amount: string;
-  last_lent_amount: string;
-  last_frozen_amount: string;
-  type: 'lend' | 'redeem';
-  create_time: number;
-}
-⋮----
-export interface LendingInterestRecord {
-  status: number;
-  currency: string;
-  actual_rate: string;
-  interest: string;
-  interest_status: string;
-  create_time: number;
-}
-
-================
-File: src/types/response/flashswap.ts
-================
-/**==========================================================================================================================
- * FLASH SWAP
- * ==========================================================================================================================
- */
-⋮----
-export interface FlashSwapCurrencyPair {
-  currency_pair: string;
-  sell_currency: string;
-  buy_currency: string;
-  sell_min_amount: string;
-  sell_max_amount: string;
-  buy_min_amount: string;
-  buy_max_amount: string;
-}
-⋮----
-export interface FlashSwapOrder {
-  id: number;
-  create_time: number;
-  user_id: number;
-  sell_currency: string;
-  sell_amount: string;
-  buy_currency: string;
-  buy_amount: string;
-  price: string;
-  status: number;
-}
-⋮----
-export interface SubmitFlashSwapOrderPreviewResp {
-  preview_id: string;
-  sell_currency: string;
-  sell_amount: string;
-  buy_currency: string;
-  buy_amount: string;
-  price: string;
-}
-
-================
-File: src/types/response/marginuni.ts
-================
-/**==========================================================================================================================
- * MARGIN UNI
- * ==========================================================================================================================
- */
-⋮----
-export interface LendingMarket {
-  currency_pair: string;
-  base_min_borrow_amount: string;
-  quote_min_borrow_amount: string;
-  leverage: string;
-}
-⋮----
-export interface MarginUNILoan {
-  currency: string;
-  currency_pair: string;
-  amount: string;
-  type: string;
-  create_time: number;
-  update_time: number;
-}
-⋮----
-export interface MarginUNILoanRecord {
-  type: string;
-  currency_pair: string;
-  currency: string;
-  amount: string;
-  create_time: number;
-}
-⋮----
-export interface MarginUNIInterestRecord {
-  currency: string;
-  currency_pair: string;
-  actual_rate: string;
-  interest: string;
-  status: number;
-  type: string;
-  create_time: number;
-}
-⋮----
-export interface MarginUNIMaxBorrowable {
-  currency: string;
-  currency_pair: string;
-  borrowable: string;
-}
-
-================
-File: src/types/response/multicollateralLoan.ts
-================
-/**==========================================================================================================================
- * MULTI COLLATERAL LOAN
- * ==========================================================================================================================
- */
-⋮----
-export interface MultiLoanOrder {
-  order_id: string;
-  order_type: string;
-  fixed_type: string;
-  fixed_rate: string;
-  expire_time: number;
-  auto_renew: boolean;
-  auto_repay: boolean;
-  current_ltv: string;
-  status: string;
-  borrow_time: number;
-  total_left_repay_usdt: string;
-  total_left_collateral_usdt: string;
-  borrow_currencies: {
-    currency: string;
-    index_price: string;
-    left_repay_principal: string;
-    left_repay_interest: string;
-    left_repay_usdt: string;
-  }[];
-  collateral_currencies: {
-    currency: string;
-    index_price: string;
-    left_collateral: string;
-    left_collateral_usdt: string;
-  }[];
-}
-⋮----
-export interface RepayMultiLoanResp {
-  order_id: number;
-  repaid_currencies: {
-    succeeded: boolean;
-    label?: string;
-    message?: string;
-    currency: string;
-    repaid_principal: string;
-    repaid_interest: string;
-  }[];
-}
-⋮----
-export interface MultiLoanRepayRecord {
-  order_id: number;
-  record_id: number;
-  init_ltv: string;
-  before_ltv: string;
-  after_ltv: string;
-  borrow_time: number;
-  repay_time: number;
-  borrow_currencies: {
-    currency: string;
-    index_price: string;
-    before_amount: string;
-    before_amount_usdt: string;
-    after_amount: string;
-    after_amount_usdt: string;
-  }[];
-  collateral_currencies: {
-    currency: string;
-    index_price: string;
-    before_amount: string;
-    before_amount_usdt: string;
-    after_amount: string;
-    after_amount_usdt: string;
-  }[];
-  repaid_currencies: {
-    currency: string;
-    index_price: string;
-    repaid_amount: string;
-    repaid_principal: string;
-    repaid_interest: string;
-    repaid_amount_usdt: string;
-  }[];
-  total_interest_list: {
-    currency: string;
-    index_price: string;
-    amount: string;
-    amount_usdt: string;
-  }[];
-  left_repay_interest_list: {
-    currency: string;
-    index_price: string;
-    before_amount: string;
-    before_amount_usdt: string;
-    after_amount: string;
-    after_amount_usdt: string;
-  }[];
-}
-⋮----
-export interface UpdateMultiLoanResp {
-  order_id: number;
-  collateral_currencies: {
-    succeeded: boolean;
-    label?: string;
-    message?: string;
-    currency: string;
-    amount: string;
-  }[];
-}
-⋮----
-export interface MultiLoanAdjustmentRecord {
-  order_id: number;
-  record_id: number;
-  before_ltv: string;
-  after_ltv: string;
-  operate_time: number;
-  borrow_currencies: {
-    currency: string;
-    index_price: string;
-    before_amount: string;
-    before_amount_usdt: string;
-    after_amount: string;
-    after_amount_usdt: string;
-  }[];
-  collateral_currencies: {
-    currency: string;
-    index_price: string;
-    before_amount: string;
-    before_amount_usdt: string;
-    after_amount: string;
-    after_amount_usdt: string;
-  }[];
-}
-⋮----
-export interface MultiLoanCurrencyQuota {
-  currency: string;
-  index_price: string;
-  min_quota: string;
-  left_quota: string;
-  left_quote_usdt: string;
-}
-⋮----
-export interface MultiLoanSupportedCurrencies {
-  loan_currencies: {
-    currency: string;
-    price: string;
-  }[];
-  collateral_currencies: {
-    currency: string;
-    index_price: string;
-    discount: string;
-  }[];
-}
-⋮----
-export interface MultiLoanRatio {
-  init_ltv: string;
-  alert_ltv: string;
-  liquidate_ltv: string;
-}
-⋮----
-export interface MultiLoanFixedRate {
-  currency: string;
-  rate_7d: string;
-  rate_30d: string;
-  update_time: number;
-}
-
-================
-File: src/types/response/options.ts
-================
-/**==========================================================================================================================
- * OPTIONS
- * ==========================================================================================================================
- */
-⋮----
-export interface OptionsContract {
-  name: string;
-  tag: string;
-  create_time: number;
-  expiration_time: number;
-  is_call: boolean;
-  strike_price: string;
-  last_price: string;
-  mark_price: string;
-  orderbook_id: number;
-  trade_id: number;
-  trade_size: number;
-  position_size: number;
-  underlying: string;
-  underlying_price: string;
-  multiplier: string;
-  order_price_round: string;
-  mark_price_round: string;
-  maker_fee_rate: string;
-  taker_fee_rate: string;
-  price_limit_fee_rate: string;
-  ref_discount_rate: string;
-  ref_rebate_rate: string;
-  order_price_deviate: string;
-  order_size_min: number;
-  order_size_max: number;
-  orders_limit: number;
-}
-⋮----
-export interface OptionsSettlementHistoryRecord {
-  time: number;
-  contract: string;
-  profit: string;
-  fee: string;
-  strike_price: string;
-  settle_price: string;
-}
-⋮----
-export interface OptionsUserSettlement {
-  time: number;
-  underlying: string;
-  contract: string;
-  strike_price: string;
-  settle_price: string;
-  size: number;
-  settle_profit: string;
-  fee: string;
-  realised_pnl: string;
-}
-⋮----
-export interface OptionsOrderBook {
-  id?: number;
-  current: number;
-  update: number;
-  asks: { p: string; s: number }[];
-  bids: { p: string; s: number }[];
-}
-⋮----
-export interface OptionsTicker {
-  name: string;
-  last_price: string;
-  mark_price: string;
-  index_price: string;
-  ask1_size: number;
-  ask1_price: string;
-  bid1_size: number;
-  bid1_price: string;
-  position_size: number;
-  mark_iv: string;
-  bid_iv: string;
-  ask_iv: string;
-  leverage: string;
-  delta: string;
-  gamma: string;
-  vega: string;
-  theta: string;
-  rho: string;
-}
-⋮----
-export interface OptionsCandle {
-  t: number;
-  v?: number;
-  c: string;
-  h: string;
-  l: string;
-  o: string;
-}
-⋮----
-export interface OptionsUnderlyingCandle {
-  t: number;
-  v?: number;
-  c: string;
-  h: string;
-  l: string;
-  o: string;
-  sum: string;
-}
-⋮----
-export interface OptionsTrade {
-  id: number;
-  create_time: number;
-  create_time_ms: number;
-  contract: string;
-  size: number;
-  price: string;
-  is_internal?: boolean;
-}
-⋮----
-export interface OptionsAccount {
-  user: number;
-  total: string;
-  short_enabled: boolean;
-  unrealised_pnl: string;
-  init_margin: string;
-  maint_margin: string;
-  order_margin: string;
-  available: string;
-  point: string;
-  currency: string;
-}
-export interface OptionsAccountChangeRecord {
-  time: number;
-  change: string;
-  balance: string;
-  type: 'dnw' | 'prem' | 'fee' | 'refr' | 'set';
-  text: string;
-}
-⋮----
-export interface OptionsPositionsUnderlying {
-  user: number;
-  underlying: string;
-  underlying_price: string;
-  contract: string;
-  size: number;
-  entry_price: string;
-  mark_price: string;
-  mark_iv: string;
-  realised_pnl: string;
-  unrealised_pnl: string;
-  pending_orders: number;
-  close_order: {
-    id: number;
-    price: string;
-    is_liq: boolean;
-  } | null;
-  delta: string;
-  gamma: string;
-  vega: string;
-  theta: string;
-}
-⋮----
-export interface GetOptionsLiquidationResp {
-  time: number;
-  contract: string;
-  side: 'long' | 'short';
-  pnl: string;
-  text: string;
-  settle_size: string;
-}
-⋮----
-export interface SubmitOptionsOrderResp {
-  id: number;
-  user: number;
-  create_time: number;
-  finish_time: number;
-  finish_as:
-    | 'filled'
-    | 'cancelled'
-    | 'liquidated'
-    | 'ioc'
-    | 'auto_deleveraged'
-    | 'reduce_only'
-    | 'position_closed';
-  status: 'open' | 'finished';
-  contract: string;
-  size: number;
-  iceberg: number;
-  price: string;
-  is_close: boolean;
-  is_reduce_only: boolean;
-  is_liq: boolean;
-  tif: 'gtc' | 'ioc' | 'poc';
-  left: number;
-  fill_price: string;
-  text: string;
-  tkfr: string;
-  mkfr: string;
-  refu: number;
-  refr: string;
-}
-⋮----
-export interface OptionsUserHistoryRecord {
-  id: number;
-  create_time: number;
-  contract: string;
-  order_id: number;
-  size: number;
-  price: string;
-  underlying_price: string;
-  role: 'taker' | 'maker';
-}
-⋮----
-export interface OptionsMMPSettings {
-  underlying: string;
-  window: number;
-  frozen_period: number;
-  qty_limit: string;
-  delta_limit: string;
-  trigger_time_ms: number; // Trigger freeze time in milliseconds, 0 means no freeze triggered
-  frozen_until_ms: number; // Unfreeze time in milliseconds, if no frozen period is configured, no unfreeze time after freeze is triggered
-}
-⋮----
-trigger_time_ms: number; // Trigger freeze time in milliseconds, 0 means no freeze triggered
-frozen_until_ms: number; // Unfreeze time in milliseconds, if no frozen period is configured, no unfreeze time after freeze is triggered
-
-================
-File: src/types/response/subaccount.ts
-================
-export interface SubAccount {
-  remark?: string;
-  login_name: string;
-  password?: string;
-  email?: string;
-  state: number;
-  type: number;
-  user_id: number;
-  create_time: number;
-}
-⋮----
-export interface CreatedSubAccountAPIKey {
-  user_id: string;
-  mode?: number;
-  name?: string;
-  perms?: {
-    name?:
-      | 'wallet'
-      | 'spot'
-      | 'futures'
-      | 'delivery'
-      | 'earn'
-      | 'options'
-      | 'account'
-      | 'unified'
-      | 'loan';
-    read_only?: boolean;
-  }[];
-  ip_whitelist?: string[];
-  key: string;
-  state: number;
-  created_at: number;
-  updated_at: number;
-  last_access: number;
-}
-⋮----
-export interface SubAccountAPIKey {
-  user_id?: string;
-  mode?: number;
-  name?: string;
-  perms?: {
-    name?:
-      | 'wallet'
-      | 'spot'
-      | 'futures'
-      | 'delivery'
-      | 'earn'
-      | 'options'
-      | 'account'
-      | 'unified'
-      | 'loan';
-    read_only?: boolean;
-  }[];
-  ip_whitelist?: string[];
-  key?: string;
-  state?: number;
-  created_at?: number;
-  updated_at?: number;
-  last_access?: number;
-}
-⋮----
-export interface SubAccountMode {
-  user_id: number;
-  is_unified: boolean;
-  mode: 'classic' | 'multi_currency' | 'portfolio';
-}
-
-================
-File: src/types/response/wallet.ts
-================
-export interface CurrencyChain {
-  chain: string;
-  name_cn: string;
-  name_en: string;
-  contract_address: string;
-  is_disabled: number;
-  is_deposit_disabled: number;
-  is_withdraw_disabled: number;
-  decimal: string;
-}
-⋮----
-export interface CreateDepositAddressResp {
-  currency: string;
-  address: string;
-  multichain_addresses: {
-    chain: string;
-    address: string;
-    payment_id: string;
-    payment_name: string;
-    obtain_failed: number;
-  }[];
-}
-⋮----
-export interface SubAccountTransferRecord {
-  currency: string;
-  sub_account: string;
-  direction: 'to' | 'from';
-  amount: string;
-  uid: string;
-  client_order_id: string;
-  timest: string;
-  source: string;
-  sub_account_type: 'spot' | 'futures' | 'cross_margin' | 'delivery';
-}
-⋮----
-export interface WithdrawalStatus {
-  currency: string;
-  name: string;
-  name_cn: string;
-  deposit: string;
-  withdraw_percent: string;
-  withdraw_fix: string;
-  withdraw_day_limit: string;
-  withdraw_amount_mini: string;
-  withdraw_day_limit_remain: string;
-  withdraw_eachtime_limit: string;
-  withdraw_fix_on_chains: { [key: string]: string };
-  withdraw_percent_on_chains: { [key: string]: string };
-}
-⋮----
-export interface SubAccountMarginBalance {
-  currency_pair: string;
-  locked: boolean;
-  risk: string;
-  base: {
-    currency: string;
-    available: string;
-    locked: string;
-    borrowed: string;
-    interest: string;
-  };
-  quote: {
-    currency: string;
-    available: string;
-    locked: string;
-    borrowed: string;
-    interest: string;
-  };
-}
-⋮----
-export interface SubAccountFuturesBalancesResp {
-  uid: string;
-  available: {
-    [key: string]: {
-      total: string;
-      unrealised_pnl: string;
-      position_margin: string;
-      order_margin: string;
-      available: string;
-      point: string;
-      currency: string;
-      in_dual_mode: boolean;
-      enable_credit: boolean;
-      position_initial_margin: string;
-      maintenance_margin: string;
-      bonus: string;
-      enable_evolved_classic: boolean;
-      cross_order_margin: string;
-      cross_initial_margin: string;
-      cross_maintenance_margin: string;
-      cross_unrealised_pnl: string;
-      cross_available: string;
-      isolated_position_margin: string;
-      history: {
-        dnw: string;
-        pnl: string;
-        fee: string;
-        refr: string;
-        fund: string;
-        point_dnw: string;
-        point_fee: string;
-        point_refr: string;
-        bonus_dnw: string;
-        bonus_offset: string;
-      };
-    };
-  };
-}
-⋮----
-export interface SubAccountCrossMarginBalancesResp {
-  uid: string;
-  available: {
-    user_id: number;
-    locked: boolean;
-    balances: {
-      [key: string]: {
-        available: string;
-        freeze: string;
-        borrowed: string;
-        interest: string;
-      };
-    };
-    total: string;
-    borrowed: string;
-    borrowed_net: string;
-    net: string;
-    leverage: string;
-    interest: string;
-    risk: string;
-    total_initial_margin: string;
-    total_margin_balance: string;
-    total_maintenance_margin: string;
-    total_initial_margin_rate: string;
-    total_maintenance_margin_rate: string;
-    total_available_margin: string;
-  };
-}
-⋮----
-export interface SavedAddress {
-  currency: string;
-  chain: string;
-  address: string;
-  name: string;
-  tag: string;
-  verified: string;
-}
-⋮----
-export interface TradingFees {
-  user_id: number;
-  taker_fee: string;
-  maker_fee: string;
-  gt_discount: boolean;
-  gt_taker_fee: string;
-  gt_maker_fee: string;
-  loan_fee: string;
-  point_type: string;
-  futures_taker_fee: string;
-  futures_maker_fee: string;
-  delivery_taker_fee: string;
-  delivery_maker_fee: string;
-  debit_fee: number;
-}
-⋮----
-export interface GetBalancesResp {
-  total: {
-    amount: string;
-    currency: string;
-    unrealised_pnl?: string;
-    borrowed?: string;
-  };
-  details: {
-    [key: string]: {
-      amount: string;
-      currency: string;
-      unrealised_pnl?: string;
-      borrowed?: string;
-    };
-  };
-}
-⋮----
-export interface SmallBalanceRecord {
-  currency: string;
-  available_balance: string;
-  estimated_as_btc: string;
-  convertible_to_gt: string;
-}
-⋮----
-export interface SmallBalanceHistoryRecord {
-  id: string;
-  currency: string;
-  amount: string;
-  gt_amount: string;
-  create_time: number;
-}
-⋮----
-export interface PushOrder {
-  id: number;
-  push_uid: number;
-  receive_uid: number;
-  currency: string;
-  amount: string;
-  create_time: number;
-  status:
-    | 'CREATING'
-    | 'PENDING'
-    | 'CANCELLING'
-    | 'CANCELLED'
-    | 'REFUSING'
-    | 'REFUSED'
-    | 'RECEIVING'
-    | 'RECEIVED';
-  message: string;
-}
-
-================
-File: src/types/response/withdrawal.ts
-================
-export interface WithdrawalRecord {
-  id: string;
-  txid: string;
-  block_number: string;
-  withdraw_order_id: string;
-  timestamp: string;
-  amount: string;
-  currency: string;
-  address: string;
-  memo?: string;
-  status:
-    | 'DONE'
-    | 'CANCEL'
-    | 'REQUEST'
-    | 'MANUAL'
-    | 'BCODE'
-    | 'EXTPEND'
-    | 'FAIL'
-    | 'INVALID'
-    | 'VERIFY'
-    | 'PROCES'
-    | 'PEND'
-    | 'DMOVE'
-    | 'SPLITPEND';
-  chain: string;
-}
-
-================
-File: src/types/websockets/client.ts
-================
-/**
- * Event args for subscribing/unsubscribing
- */
-⋮----
-// export type WsTopicSubscribePrivateArgsV2 =
-//   | WsTopicSubscribePrivateInstIdArgsV2
-//   | WsTopicSubscribePrivateCoinArgsV2;
-⋮----
-// export type WsTopicSubscribeEventArgsV2 =
-//   | WsTopicSubscribePublicArgsV2
-//   | WsTopicSubscribePrivateArgsV2;
-⋮----
-/** General configuration for the WebsocketClient */
-export interface WSClientConfigurableOptions {
-  /** Your API key */
-  apiKey?: string;
-
-  /** Your API secret */
-  apiSecret?: string;
-
-  useTestnet?: boolean;
-
-  /** Define a recv window when preparing a private websocket signature. This is in milliseconds, so 5000 == 5 seconds */
-  recvWindow?: number;
-
-  /** How often to check if the connection is alive */
-  pingInterval?: number;
-
-  /** How long to wait for a pong (heartbeat reply) before assuming the connection is dead */
-  pongTimeout?: number;
-
-  /** Delay in milliseconds before respawning the connection */
-  reconnectTimeout?: number;
-
-  requestOptions?: {};
-
-  wsUrl?: string;
-
-  /**
-   * Allows you to provide a custom "signMessage" function, e.g. to use node's much faster createHmac method
-   *
-   * Look in the examples folder for a demonstration on using node's createHmac instead.
-   */
-  customSignMessageFn?: (message: string, secret: string) => Promise<string>;
-
-  /**
-   * If you authenticated the WS API before, automatically try to re-authenticate the WS API if you're disconnected/reconnected for any reason.
-   */
-  reauthWSAPIOnReconnect?: boolean;
-}
-⋮----
-/** Your API key */
-⋮----
-/** Your API secret */
-⋮----
-/** Define a recv window when preparing a private websocket signature. This is in milliseconds, so 5000 == 5 seconds */
-⋮----
-/** How often to check if the connection is alive */
-⋮----
-/** How long to wait for a pong (heartbeat reply) before assuming the connection is dead */
-⋮----
-/** Delay in milliseconds before respawning the connection */
-⋮----
-/**
-   * Allows you to provide a custom "signMessage" function, e.g. to use node's much faster createHmac method
-   *
-   * Look in the examples folder for a demonstration on using node's createHmac instead.
-   */
-⋮----
-/**
-   * If you authenticated the WS API before, automatically try to re-authenticate the WS API if you're disconnected/reconnected for any reason.
-   */
-⋮----
-/**
- * WS configuration that's always defined, regardless of user configuration
- * (usually comes from defaults if there's no user-provided values)
- */
-export interface WebsocketClientOptions extends WSClientConfigurableOptions {
-  pingInterval: number;
-  pongTimeout: number;
-  reconnectTimeout: number;
-  recvWindow: number;
-  authPrivateConnectionsOnConnect: boolean;
-  authPrivateRequests: boolean;
-  reauthWSAPIOnReconnect: boolean;
-}
-
-================
-File: src/types/websockets/events.ts
-================
-export interface WsDataEvent<TData = any, TWSKey = string> {
-  data: TData;
-  table: string;
-  wsKey: TWSKey;
-}
-
-================
-File: src/types/websockets/requests.ts
-================
-import { CHANNEL_ID } from '../../lib/requestUtils.js';
-import { WSAPITopic } from './wsAPI.js';
-⋮----
-export type WsOperation = 'subscribe' | 'unsubscribe' | 'auth';
-⋮----
-export interface WsRequestAuthGate {
-  method: 'api_key';
-  KEY: string;
-  SIGN: string;
-}
-⋮----
-export interface WsRequestPing {
-  time: number;
-  channel: 'spot.ping' | 'futures.ping' | 'options.ping' | 'announcement.ping';
-}
-⋮----
-export interface WsRequestOperationGate<
-  TWSTopic extends string,
-  TWSPayload = any,
-> {
-  time: number;
-  id?: number;
-  channel: TWSTopic;
-  auth?: WsRequestAuthGate;
-  event?: WsOperation;
-  payload?: TWSPayload;
-}
-⋮----
-export interface WSAPIRequest<
-  TRequestParams = any,
-  TWSChannel extends WSAPITopic = any,
-> {
-  time: number;
-  id?: number;
-  channel: TWSChannel;
-  event: 'api';
-  payload: {
-    req_id: string;
-    req_param?: TRequestParams | string;
-    req_header: {
-      'X-Gate-Channel-Id': typeof CHANNEL_ID;
-    };
-    api_key?: string;
-    signature?: string;
-    timestamp?: string;
-  };
-}
-
-================
-File: .prettierrc
-================
-{
-  "tabWidth": 2,
-  "singleQuote": true,
-  "trailingComma": "all"
-}
-
-================
-File: jest.config.ts
-================
-/**
- * For a detailed explanation regarding each configuration property, visit:
- * https://jestjs.io/docs/configuration
- */
-⋮----
-import type { Config } from 'jest';
-⋮----
-// All imported modules in your tests should be mocked automatically
-// automock: false,
-⋮----
-// Stop running tests after `n` failures
-// bail: 0,
-bail: false, // enable to stop test when an error occur,
-⋮----
-// The directory where Jest should store its cached dependency information
-// cacheDirectory: "/private/var/folders/kf/2k3sz4px6c9cbyzj1h_b192h0000gn/T/jest_dx",
-⋮----
-// Automatically clear mock calls, instances, contexts and results before every test
-⋮----
-// Indicates whether the coverage information should be collected while executing the test
-⋮----
-// An array of glob patterns indicating a set of files for which coverage information should be collected
-⋮----
-// The directory where Jest should output its coverage files
-⋮----
-// An array of regexp pattern strings used to skip coverage collection
-// coveragePathIgnorePatterns: [
-//   "/node_modules/"
-// ],
-⋮----
-// Indicates which provider should be used to instrument code for coverage
-⋮----
-// A list of reporter names that Jest uses when writing coverage reports
-// coverageReporters: [
-//   "json",
-//   "text",
-//   "lcov",
-//   "clover"
-// ],
-⋮----
-// An object that configures minimum threshold enforcement for coverage results
-// coverageThreshold: undefined,
-⋮----
-// A path to a custom dependency extractor
-// dependencyExtractor: undefined,
-⋮----
-// Make calling deprecated APIs throw helpful error messages
-// errorOnDeprecated: false,
-⋮----
-// The default configuration for fake timers
-// fakeTimers: {
-//   "enableGlobally": false
-// },
-⋮----
-// Force coverage collection from ignored files using an array of glob patterns
-// forceCoverageMatch: [],
-⋮----
-// A path to a module which exports an async function that is triggered once before all test suites
-// globalSetup: undefined,
-⋮----
-// A path to a module which exports an async function that is triggered once after all test suites
-// globalTeardown: undefined,
-⋮----
-// A set of global variables that need to be available in all test environments
-// globals: {},
-⋮----
-// The maximum amount of workers used to run your tests. Can be specified as % or a number. E.g. maxWorkers: 10% will use 10% of your CPU amount + 1 as the maximum worker number. maxWorkers: 2 will use a maximum of 2 workers.
-// maxWorkers: "50%",
-⋮----
-// An array of directory names to be searched recursively up from the requiring module's location
-// moduleDirectories: [
-//   "node_modules"
-// ],
-⋮----
-// An array of file extensions your modules use
-⋮----
-// modulePaths: ['src'],
-⋮----
-// A map from regular expressions to module names or to arrays of module names that allow to stub out resources with a single module
-// moduleNameMapper: {},
-⋮----
-// An array of regexp pattern strings, matched against all module paths before considered 'visible' to the module loader
-// modulePathIgnorePatterns: [],
-⋮----
-// Activates notifications for test results
-// notify: false,
-⋮----
-// An enum that specifies notification mode. Requires { notify: true }
-// notifyMode: "failure-change",
-⋮----
-// A preset that is used as a base for Jest's configuration
-// preset: undefined,
-⋮----
-// Run tests from one or more projects
-// projects: undefined,
-⋮----
-// Use this configuration option to add custom reporters to Jest
-// reporters: undefined,
-⋮----
-// Automatically reset mock state before every test
-// resetMocks: false,
-⋮----
-// Reset the module registry before running each individual test
-// resetModules: false,
-⋮----
-// A path to a custom resolver
-// resolver: undefined,
-⋮----
-// Automatically restore mock state and implementation before every test
-// restoreMocks: false,
-⋮----
-// The root directory that Jest should scan for tests and modules within
-// rootDir: undefined,
-⋮----
-// A list of paths to directories that Jest should use to search for files in
-// roots: [
-//   "<rootDir>"
-// ],
-⋮----
-// Allows you to use a custom runner instead of Jest's default test runner
-// runner: "jest-runner",
-⋮----
-// The paths to modules that run some code to configure or set up the testing environment before each test
-// setupFiles: [],
-⋮----
-// A list of paths to modules that run some code to configure or set up the testing framework before each test
-// setupFilesAfterEnv: [],
-⋮----
-// The number of seconds after which a test is considered as slow and reported as such in the results.
-// slowTestThreshold: 5,
-⋮----
-// A list of paths to snapshot serializer modules Jest should use for snapshot testing
-// snapshotSerializers: [],
-⋮----
-// The test environment that will be used for testing
-// testEnvironment: "jest-environment-node",
-⋮----
-// Options that will be passed to the testEnvironment
-// testEnvironmentOptions: {},
-⋮----
-// Adds a location field to test results
-// testLocationInResults: false,
-⋮----
-// The glob patterns Jest uses to detect test files
-⋮----
-// "**/__tests__/**/*.[jt]s?(x)",
-⋮----
-// An array of regexp pattern strings that are matched against all test paths, matched tests are skipped
-// testPathIgnorePatterns: [
-//   "/node_modules/"
-// ],
-⋮----
-// The regexp pattern or array of patterns that Jest uses to detect test files
-// testRegex: [],
-⋮----
-// This option allows the use of a custom results processor
-// testResultsProcessor: undefined,
-⋮----
-// This option allows use of a custom test runner
-// testRunner: "jest-circus/runner",
-⋮----
-// A map from regular expressions to paths to transformers
-// transform: undefined,
-⋮----
-// An array of regexp pattern strings that are matched against all source file paths, matched files will skip transformation
-// transformIgnorePatterns: [
-//   "/node_modules/",
-//   "\\.pnp\\.[^\\/]+$"
-// ],
-⋮----
-// Prevents import esm module error from v1 axios release, issue #5026
-⋮----
-// An array of regexp pattern strings that are matched against all modules before the module loader will automatically return a mock for them
-// unmockedModulePathPatterns: undefined,
-⋮----
-// Indicates whether each individual test should be reported during the run
-// verbose: undefined,
-verbose: true, // report individual test
-⋮----
-// An array of regexp patterns that are matched against all source file paths before re-running tests in watch mode
-// watchPathIgnorePatterns: [],
-⋮----
-// Whether to use watchman for file crawling
-// watchman: true,
-
-================
-File: LICENSE.md
-================
-Copyright 2022 Tiago Siebler
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
-================
-File: postBuild.sh
-================
-#!/bin/bash
-#
-#   Add package.json files to cjs/mjs subtrees
-#
-
-cat >dist/cjs/package.json <<!EOF
-{
-    "type": "commonjs"
-}
-!EOF
-
-cat >dist/mjs/package.json <<!EOF
-{
-    "type": "module"
-}
-!EOF
-
-find src -name '*.d.ts' -exec cp {} dist/mjs \;
-find src -name '*.d.ts' -exec cp {} dist/cjs \;
-
-================
-File: tea.yaml
-================
----
-version: 1.0.0
-codeOwners:
-  - '0xeb1a7BF44a801e33a339705A266Afc0Cba3D6D54'
-quorum: 1
-
-================
-File: tsconfig.cjs.json
-================
-{
-  "extends": "./tsconfig.json",
-  "compilerOptions": {
-    "module": "commonjs",
-    "outDir": "dist/cjs",
-    "target": "esnext"
-  },
-  "include": ["src/**/*.*"]
-}
-
-================
-File: tsconfig.esm.json
-================
-{
-  "extends": "./tsconfig.json",
-  "compilerOptions": {
-    "module": "esnext",
-    "outDir": "dist/mjs",
-    "target": "esnext"
-  },
-  "include": ["src/**/*.*"]
-}
-
-================
-File: tsconfig.linting.json
-================
-{
-  "extends": "./tsconfig.json",
-  "compilerOptions": {
-    "module": "commonjs",
-    "outDir": "dist/cjs",
-    "target": "esnext",
-    "rootDir": "../",
-    "allowJs": true
-  },
-  "include": [
-    "src/**/*.*",
-    "test/**/*.*",
-    "examples/**/*.*",
-    ".eslintrc.cjs",
-    "jest.config.ts"
-  ]
-}
-
-================
-File: examples/futures/testnet.ts
-================
-import { RestClient } from '../../src/index.js'; // For an easy demonstration, import from the src dir. Normally though, see below to import from the npm installed version instead.
-// import { RestClient } from 'gateio-api'; // Import the RestClient from the published version of this SDK, installed via NPM (npm install gateio-api)
-⋮----
-// Define the account object with API key and secret
-⋮----
-key: process.env.API_KEY || 'yourApiHere', // Replace 'yourApiHere' with your actual API key
-secret: process.env.API_SECRET || 'yourSecretHere', // Replace 'yourSecretHere' with your actual API secret
-⋮----
-// Initialize the RestClient with the API credentials
-⋮----
-/**
-   * To use a different base URL, use the baseUrl key. The SDK uses the live environment by default:
-   * baseUrlKey: 'live',
-   *'https://api.gateio.ws/api/v4'
-   * But you can force it to use any of the available environments. Examples below.
-   */
-⋮----
-/*
-   * Futures TestNet trading:
-   * 'https://fx-api-testnet.gateio.ws/api/v4'
-   */
-⋮----
-/**
-   * Futures live trading alternative (futures only):
-   * 'https://fx-api.gateio.ws/api/v4'
-   */
-// baseUrlKey: 'futuresLiveAlternative'
-⋮----
-async function submitFuturesOrder()
-⋮----
-// Submit a market order for futures trading
-⋮----
-settle: 'usdt', // Specify the settlement currency
-contract: 'BTC_USDT', // Specify the contract
-size: 20, // Order size: positive for long, negative for short
-price: '0', // Market order, so price is set to '0'
-tif: 'ioc', // Time in force: 'ioc' (Immediate Or Cancel)
-⋮----
-console.log('Response: ', result); // Log the response to the console
-⋮----
-console.error(`Error in execution: `, e); // Log any errors that occur
-⋮----
-// Execute the function to submit a futures order
-
-================
-File: examples/ws-private-perp-futures-wsapi.ts
-================
-/* eslint-disable @typescript-eslint/no-unused-vars */
-⋮----
-import { LogParams, WebsocketClient } from '../src/index.js';
-// import { LogParams, WebsocketClient } from 'gateio-api'; // normally you should install this module via npm: `npm install gateio-api`
-⋮----
-// Define a custom logger object to handle logging at different levels
-⋮----
-// Trace level logging: used for detailed debugging information
-⋮----
-// Uncomment the line below to enable trace logging
-// console.log(new Date(), 'trace', ...params);
-⋮----
-// Info level logging: used for general informational messages
-⋮----
-// Error level logging: used for error messages
-⋮----
-async function start()
-⋮----
-// See comments below about event-driven vs promise-driven. Not needed if using the promise-driven approach
-// client.on('update', (data) => {
-//   // console.info(new Date(), 'ws data received: ', JSON.stringify(data));
-//   console.info(new Date(), 'ws data received: ', JSON.stringify(data, null, 2));
-// });
-⋮----
-// Something happened, attempting to reconnect
-⋮----
-// Reconnect successful
-⋮----
-// Connection closed. If unexpected, expect reconnect -> reconnected.
-⋮----
-// Reply to a request, e.g. "subscribe"/"unsubscribe"/"authenticate"
-// See comments below about event-driven vs promise-driven. Not needed if using the promise-driven approach
-// client.on('response', (data) => {
-//   console.info(
-//     new Date(),
-//     'ws server reply ',
-//     JSON.stringify(data, null, 2),
-//     '\n',
-//   );
-// });
-⋮----
-// Optional, listen to this event if you prefer the event-driven approach.
-// See below comments on event-driven vs promise-driven.
-// client.on('authenticated', (data) => {
-//   console.error(new Date(), 'ws authenticated: ', data);
-// });
-⋮----
-/**
-     * All WebSocket API (WS API) messaging should be done via the sendWSAPIRequest method.
-     *
-     * You have two ways to handle responses on the WS API. You can either:
-     * - event-driven: process async `response` and `update` events from the websocket client, OR
-     * - promise-driven: await every call to `client.sendWSAPIRequest`, this can behave similar to using a REST API (successful responses resolve, exceptions reject).
-     */
-⋮----
-/**
-     * To authenticate, send an empty request to "futures.login". The SDK will handle all the parameters.
-     *
-     * Optional - you can inject rich types to set the response type
-     *    const loginResult = await client.sendWSAPIRequest<WSAPIResponse<WSAPILoginResponse>>('perpFuturesUSDTV4', 'futures.login');
-     */
-⋮----
-/**
-     * For other channels, the 3rd parameter should have any parameters for the request (the payload).
-     *
-     * Note that internal parameters such as "signature" etc are all handled automatically by the SDK.
-     *
-     */
-⋮----
-/**
-     * Submit futures order
-     */
-⋮----
-size: 20, // positive for long, negative for short
-⋮----
-/**
-     * Submit batch futures order
-     */
-⋮----
-size: 10, // positive for long, negative for short
-⋮----
-size: 10, // positive for long, negative for short
-⋮----
-/**
-     * Cancel futures order
-     */
-⋮----
-/**
-     * Cancel all futures orders
-     */
-⋮----
-/**
-     * Update/Amend Futures order
-     */
-⋮----
-/**
-     * Get orders list
-     */
-⋮----
-/**
-     * Get order status
-     */
-
-================
-File: examples/ws-private-perp-futures.ts
-================
-/* eslint-disable @typescript-eslint/no-unused-vars */
-import { LogParams, WebsocketClient, WsTopicRequest } from '../src/index.js';
-// import { LogParams, WebsocketClient, WsTopicRequest } from 'gateio-api'; // normally you should install this module via npm: `npm install gateio-api`
-⋮----
-// Define a custom logger object to handle logging at different levels
-⋮----
-// Trace level logging: used for detailed debugging information
-⋮----
-// Uncomment the line below to enable trace logging
-// console.log(new Date(), 'trace', ...params);
-⋮----
-// Info level logging: used for general informational messages
-⋮----
-// Error level logging: used for error messages
-⋮----
-async function start()
-⋮----
-// console.log('auth with: ', account);
-⋮----
-// Data received
-⋮----
-// Something happened, attempting to reconnect
-⋮----
-// Reconnect successful
-⋮----
-// Connection closed. If unexpected, expect reconnect -> reconnected.
-⋮----
-// Reply to a request, e.g. "subscribe"/"unsubscribe"/"authenticate"
-⋮----
-// TODO: many private topics use your user ID
-⋮----
-/**
-     * Either send one topic (with params) at a time
-     */
-// client.subscribe({
-//   topic: 'futures.usertrades',
-//   payload: [myUserID, '!all'],
-// }, 'perpFuturesUSDTV4');
-⋮----
-/**
-     * Or send multiple topics in a batch (grouped by ws connection (WsKey))
-     * You can also use strings for topics that don't have any parameters, even if you mix multiple requests into one function call:
-     */
-
-================
-File: examples/ws-private-spot.ts
-================
-/* eslint-disable @typescript-eslint/no-unused-vars */
-import { LogParams, WebsocketClient, WsTopicRequest } from '../src/index.js';
-// import { LogParams, WebsocketClient, WsTopicRequest } from 'gateio-api'; // normally you should install this module via npm: `npm install gateio-api`
-⋮----
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-⋮----
-// Define a custom logger object to handle logging at different levels
-⋮----
-// Trace level logging: used for detailed debugging information
-⋮----
-// Uncomment the line below to enable trace logging
-// console.log(new Date(), 'trace', ...params);
-⋮----
-// Info level logging: used for general informational messages
-⋮----
-// Error level logging: used for error messages
-⋮----
-async function start()
-⋮----
-// console.log('auth with: ', account);
-⋮----
-// Data received
-⋮----
-// Something happened, attempting to reconnect
-⋮----
-// Reconnect successful
-⋮----
-// Connection closed. If unexpected, expect reconnect -> reconnected.
-⋮----
-// Reply to a request, e.g. "subscribe"/"unsubscribe"/"authenticate"
-⋮----
-// client.subscribe(topics, 'spotV4');
-⋮----
-// This has the same effect as above, it's just a different way of messaging which topic this is for
-// const topicWithoutParamsAsObject: WsTopicRequest = {
-//   topic: 'spot.balances',
-// };
-⋮----
-/**
-     * Either send one topic (with optional params) at a time
-     */
-// client.subscribe(topicWithoutParamsAsObject, 'spotV4');
-⋮----
-/**
-     * Or send multiple topics in a batch (grouped by ws connection (WsKey))
-     * You can also use strings for topics that don't have any parameters, even if you mix multiple requests into one function call:
-     */
-⋮----
-/**
-     * You can also subscribe in separate function calls as you wish.
-     *
-     * Any duplicate requests should get filtered out (e.g. here we subscribed to "spot.balances" twice, but the WS client will filter this out)
-     */
-
-================
-File: examples/ws-public.ts
-================
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-import { WebsocketClient, WsTopicRequest } from '../src/index.js';
-// import { LogParams, WebsocketClient, WsTopicRequest } from 'gateio-api'; // normally you should install this module via npm: `npm install gateio-api`
-⋮----
-// const customLogger = {
-//   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-//   trace: (...params: LogParams): void => {
-//     console.log('trace', ...params);
-//   },
-//   info: (...params: LogParams): void => {
-//     console.log('info', ...params);
-//   },
-//   error: (...params: LogParams): void => {
-//     console.error('error', ...params);
-//   },
-// };
-⋮----
-async function start()
-⋮----
-// Optional, inject a custom logger
-// const client = new WebsocketClient({}, customLogger);
-⋮----
-// Data received
-⋮----
-// Something happened, attempting to reconnect
-⋮----
-// Reconnect successful
-⋮----
-// Connection closed. If unexpected, expect reconnect -> reconnected.
-⋮----
-// Reply to a request, e.g. "subscribe"/"unsubscribe"/"authenticate"
-⋮----
-// const topicWithoutParamsAsString = 'spot.balances';
-⋮----
-// This has the same effect as above, it's just a different way of messaging which topic this is for
-// const topicWithoutParamsAsObject: WsTopicRequest = {
-//   topic: 'spot.balances',
-// };
-⋮----
-/**
-     * Either send one topic (with optional params) at a time
-     */
-// client.subscribe(tickersRequestWithParams, 'spotV4');
-⋮----
-/**
-     * Or send multiple topics in a batch (grouped by ws connection (WsKey))
-     */
-⋮----
-// /**
-//  * You can also use strings for topics that don't have any parameters, even if you mix multiple requests into one function call:
-//  */
-// client.subscribe(
-//   [tickersRequestWithParams, rawTradesRequestWithParams, topicWithoutParamsAsString],
-//   'spotV4',
-// );
-
-================
-File: src/lib/websocket/WsStore.ts
-================
-import WebSocket from 'isomorphic-ws';
-⋮----
-import { DefaultLogger } from '../logger.js';
-import {
-  DeferredPromise,
-  WSConnectedResult,
-  WsConnectionStateEnum,
-  WsStoredState,
-} from './WsStore.types.js';
-⋮----
-/**
- * Simple comparison of two objects, only checks 1-level deep (nested objects won't match)
- */
-export function isDeepObjectMatch(object1: unknown, object2: unknown): boolean
-⋮----
-type DeferredPromiseRef =
-  (typeof DEFERRED_PROMISE_REF)[keyof typeof DEFERRED_PROMISE_REF];
-⋮----
-export class WsStore<
-WsKey extends string,
-⋮----
-constructor(logger: DefaultLogger)
-⋮----
-/** Get WS stored state for key, optionally create if missing */
-get(
-    key: WsKey,
-    createIfMissing?: true,
-  ): WsStoredState<TWSTopicSubscribeEventArgs>;
-⋮----
-get(
-    key: WsKey,
-    createIfMissing?: false,
-  ): WsStoredState<TWSTopicSubscribeEventArgs> | undefined;
-⋮----
-get(
-    key: WsKey,
-    createIfMissing?: boolean,
-): WsStoredState<TWSTopicSubscribeEventArgs> | undefined
-⋮----
-getKeys(): WsKey[]
-⋮----
-create(key: WsKey): WsStoredState<TWSTopicSubscribeEventArgs> | undefined
-⋮----
-delete(key: WsKey): void
-⋮----
-// TODO: should we allow this at all? Perhaps block this from happening...
-⋮----
-/* connection websocket */
-⋮----
-hasExistingActiveConnection(key: WsKey): boolean
-⋮----
-getWs(key: WsKey): WebSocket | undefined
-⋮----
-setWs(key: WsKey, wsConnection: WebSocket): WebSocket
-⋮----
-/**
-   * deferred promises
-   */
-⋮----
-getDeferredPromise<TSuccessResult = any>(
-    wsKey: WsKey,
-    promiseRef: string | DeferredPromiseRef,
-): DeferredPromise<TSuccessResult> | undefined
-⋮----
-createDeferredPromise<TSuccessResult = any>(
-    wsKey: WsKey,
-    promiseRef: string | DeferredPromiseRef,
-    throwIfExists: boolean,
-): DeferredPromise<TSuccessResult>
-⋮----
-// console.log('existing promise');
-⋮----
-// console.log('create promise');
-⋮----
-// TODO: Once stable, use Promise.withResolvers in future
-⋮----
-resolveDeferredPromise(
-    wsKey: WsKey,
-    promiseRef: string | DeferredPromiseRef,
-    value: unknown,
-    removeAfter: boolean,
-): void
-⋮----
-rejectDeferredPromise(
-    wsKey: WsKey,
-    promiseRef: string | DeferredPromiseRef,
-    value: unknown,
-    removeAfter: boolean,
-): void
-⋮----
-removeDeferredPromise(
-    wsKey: WsKey,
-    promiseRef: string | DeferredPromiseRef,
-): void
-⋮----
-// Just in case it's pending
-⋮----
-rejectAllDeferredPromises(wsKey: WsKey, reason: string): void
-⋮----
-// Skip reserved keys, such as the connection promise
-⋮----
-/** Get promise designed to track a connection attempt in progress. Resolves once connected. */
-getConnectionInProgressPromise(
-    wsKey: WsKey,
-): DeferredPromise<WSConnectedResult> | undefined
-⋮----
-getAuthenticationInProgressPromise(
-    wsKey: WsKey,
-): DeferredPromise<WSConnectedResult &
-⋮----
-/**
-   * Create a deferred promise designed to track a connection attempt in progress.
-   *
-   * Will throw if existing promise is found.
-   */
-createConnectionInProgressPromise(
-    wsKey: WsKey,
-    throwIfExists: boolean,
-): DeferredPromise<WSConnectedResult>
-⋮----
-createAuthenticationInProgressPromise(
-    wsKey: WsKey,
-    throwIfExists: boolean,
-): DeferredPromise<WSConnectedResult &
-⋮----
-/** Remove promise designed to track a connection attempt in progress */
-removeConnectingInProgressPromise(wsKey: WsKey): void
-⋮----
-removeAuthenticationInProgressPromise(wsKey: WsKey): void
-⋮----
-/* connection state */
-⋮----
-isWsOpen(key: WsKey): boolean
-⋮----
-getConnectionState(key: WsKey): WsConnectionStateEnum
-⋮----
-setConnectionState(key: WsKey, state: WsConnectionStateEnum)
-⋮----
-isConnectionState(key: WsKey, state: WsConnectionStateEnum): boolean
-⋮----
-/**
-   * Check if we're currently in the process of opening a connection for any reason. Safer than only checking "CONNECTING" as the state
-   * @param key
-   * @returns
-   */
-isConnectionAttemptInProgress(key: WsKey): boolean
-⋮----
-const stateChangeTimeout = 15000; // allow a max 15 second timeout since the last state change before assuming stuck;
-⋮----
-/* subscribed topics */
-⋮----
-getTopics(key: WsKey): Set<TWSTopicSubscribeEventArgs>
-⋮----
-getTopicsByKey(): Record<string, Set<TWSTopicSubscribeEventArgs>>
-⋮----
-/**
-   * Find matching "topic" request from the store
-   * @param key
-   * @param topic
-   * @returns
-   */
-getMatchingTopic(key: WsKey, topic: TWSTopicSubscribeEventArgs)
-⋮----
-addTopic(key: WsKey, topic: TWSTopicSubscribeEventArgs)
-⋮----
-// Check for duplicate topic. If already tracked, don't store this one
-⋮----
-deleteTopic(key: WsKey, topic: TWSTopicSubscribeEventArgs)
-⋮----
-// Check if we're subscribed to a topic like this
-
-================
-File: src/lib/websocket/WsStore.types.ts
-================
-/* eslint-disable @typescript-eslint/no-explicit-any */
-import WebSocket from 'isomorphic-ws';
-⋮----
-export enum WsConnectionStateEnum {
-  INITIAL = 0,
-  CONNECTING = 1,
-  CONNECTED = 2,
-  CLOSING = 3,
-  RECONNECTING = 4,
-  // ERROR_RECONNECTING = 5,
-  ERROR = 5,
-}
-⋮----
-// ERROR_RECONNECTING = 5,
-⋮----
-export interface DeferredPromise<TSuccess = any, TError = any> {
-  resolve?: (value: TSuccess) => TSuccess;
-  reject?: (value: TError) => TError;
-  promise?: Promise<TSuccess>;
-}
-⋮----
-export interface WSConnectedResult {
-  wsKey: string;
-  ws: WebSocket;
-}
-⋮----
-export interface WsStoredState<TWSTopicSubscribeEvent extends string | object> {
-  /** The currently active websocket connection */
-  ws?: WebSocket;
-  /** The current lifecycle state of the connection (enum) */
-  connectionState?: WsConnectionStateEnum;
-  connectionStateChangedAt?: Date;
-  /** A timer that will send an upstream heartbeat (ping) when it expires */
-  activePingTimer?: ReturnType<typeof setTimeout> | undefined;
-  /** A timer tracking that an upstream heartbeat was sent, expecting a reply before it expires */
-  activePongTimer?: ReturnType<typeof setTimeout> | undefined;
-  /** If a reconnection is in progress, this will have the timer for the delayed reconnect */
-  activeReconnectTimer?: ReturnType<typeof setTimeout> | undefined;
-  /**
-   * When a connection attempt is in progress (even for reconnect), a promise is stored here.
-   *
-   * This promise will resolve once connected (and will then get removed);
-   */
-  // connectionInProgressPromise?: DeferredPromise | undefined;
-  deferredPromiseStore: Record<string, DeferredPromise>;
-  /**
-   * All the topics we are expected to be subscribed to on this connection (and we automatically resubscribe to if the connection drops)
-   *
-   * A "Set" and a deep-object-match are used to ensure we only subscribe to a
-   * topic once (tracking a list of unique topics we're expected to be connected to)
-   */
-  subscribedTopics: Set<TWSTopicSubscribeEvent>;
-  /** Whether this connection has completed authentication (only applies to private connections) */
-  isAuthenticated?: boolean;
-  /**
-   * Whether this connection has completed authentication before for the Websocket API, so it k
-   * nows to automatically reauth if reconnected
-   */
-  didAuthWSAPI?: boolean;
-  /** To reauthenticate on the WS API, which channel do we send to? */
-  WSAPIAuthChannel?: string;
-}
-⋮----
-/** The currently active websocket connection */
-⋮----
-/** The current lifecycle state of the connection (enum) */
-⋮----
-/** A timer that will send an upstream heartbeat (ping) when it expires */
-⋮----
-/** A timer tracking that an upstream heartbeat was sent, expecting a reply before it expires */
-⋮----
-/** If a reconnection is in progress, this will have the timer for the delayed reconnect */
-⋮----
-/**
-   * When a connection attempt is in progress (even for reconnect), a promise is stored here.
-   *
-   * This promise will resolve once connected (and will then get removed);
-   */
-// connectionInProgressPromise?: DeferredPromise | undefined;
-⋮----
-/**
-   * All the topics we are expected to be subscribed to on this connection (and we automatically resubscribe to if the connection drops)
-   *
-   * A "Set" and a deep-object-match are used to ensure we only subscribe to a
-   * topic once (tracking a list of unique topics we're expected to be connected to)
-   */
-⋮----
-/** Whether this connection has completed authentication (only applies to private connections) */
-⋮----
-/**
-   * Whether this connection has completed authentication before for the Websocket API, so it k
-   * nows to automatically reauth if reconnected
-   */
-⋮----
-/** To reauthenticate on the WS API, which channel do we send to? */
-
-================
-File: src/lib/logger.ts
-================
-export type LogParams = null | any;
-⋮----
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-⋮----
-// console.log(_params);
-⋮----
-export type DefaultLogger = typeof DefaultLogger;
-
-================
-File: src/lib/requestUtils.ts
-================
-import WebSocket from 'isomorphic-ws';
-⋮----
-import { GateBaseUrlKey } from '../types/shared.js';
-⋮----
-export interface RestClientOptions {
-  /** Your API key */
-  apiKey?: string;
-
-  /** Your API secret */
-  apiSecret?: string;
-
-  /**
-   * Override the default/global max size of the request window (in ms) for signed api calls.
-   * If you don't include a recv window when making an API call, this value will be used as default
-   */
-  recvWindow?: number;
-
-  /** Default: false. If true, we'll throw errors if any params are undefined */
-  strictParamValidation?: boolean;
-
-  /**
-   * Optionally override API protocol + domain
-   * e.g baseUrl: 'https://api.gate.io'
-   **/
-  baseUrl?: string;
-
-  // manually override with one of the known base URLs in the library
-  baseUrlKey?: GateBaseUrlKey;
-
-  /** Default: true. whether to try and post-process request exceptions (and throw them). */
-  parseExceptions?: boolean;
-
-  /**
-   * Enable keep alive for REST API requests (via axios).
-   * See: https://github.com/tiagosiebler/bybit-api/issues/368
-   */
-  keepAlive?: boolean;
-
-  /**
-   * When using HTTP KeepAlive, how often to send TCP KeepAlive packets over sockets being kept alive. Default = 1000.
-   * Only relevant if keepAlive is set to true.
-   * Default: 1000 (defaults comes from https agent)
-   */
-  keepAliveMsecs?: number;
-
-  /**
-   * Allows you to provide a custom "signMessage" function, e.g. to use node's much faster createHmac method
-   *
-   * Look in the examples folder for a demonstration on using node's createHmac instead.
-   */
-  customSignMessageFn?: (message: string, secret: string) => Promise<string>;
-}
-⋮----
-/** Your API key */
-⋮----
-/** Your API secret */
-⋮----
-/**
-   * Override the default/global max size of the request window (in ms) for signed api calls.
-   * If you don't include a recv window when making an API call, this value will be used as default
-   */
-⋮----
-/** Default: false. If true, we'll throw errors if any params are undefined */
-⋮----
-/**
-   * Optionally override API protocol + domain
-   * e.g baseUrl: 'https://api.gate.io'
-   **/
-⋮----
-// manually override with one of the known base URLs in the library
-⋮----
-/** Default: true. whether to try and post-process request exceptions (and throw them). */
-⋮----
-/**
-   * Enable keep alive for REST API requests (via axios).
-   * See: https://github.com/tiagosiebler/bybit-api/issues/368
-   */
-⋮----
-/**
-   * When using HTTP KeepAlive, how often to send TCP KeepAlive packets over sockets being kept alive. Default = 1000.
-   * Only relevant if keepAlive is set to true.
-   * Default: 1000 (defaults comes from https agent)
-   */
-⋮----
-/**
-   * Allows you to provide a custom "signMessage" function, e.g. to use node's much faster createHmac method
-   *
-   * Look in the examples folder for a demonstration on using node's createHmac instead.
-   */
-⋮----
-export function serializeParams<T extends Record<string, any> | undefined = {}>(
-  params: T,
-  strict_validation: boolean | undefined,
-  encodeValues: boolean,
-  prefixWith: string,
-): string
-⋮----
-// Only prefix if there's a value
-⋮----
-export function getRestBaseUrl(restClientOptions: RestClientOptions): string
-⋮----
-export interface MessageEventLike {
-  target: WebSocket;
-  type: 'message';
-  data: string;
-}
-⋮----
-export function isMessageEvent(msg: unknown): msg is MessageEventLike
-
-================
-File: src/lib/webCryptoAPI.ts
-================
-import { neverGuard } from './misc-util.js';
-⋮----
-function bufferToB64(buffer: ArrayBuffer): string
-⋮----
-export type SignEncodeMethod = 'hex' | 'base64';
-export type SignAlgorithm = 'SHA-256' | 'SHA-512';
-⋮----
-/**
- * Similar to node crypto's `createHash()` function
- */
-export async function hashMessage(
-  message: string,
-  method: SignEncodeMethod,
-  algorithm: SignAlgorithm,
-): Promise<string>
-⋮----
-/**
- * Sign a message, with a secret, using the Web Crypto API
- */
-export async function signMessage(
-  message: string,
-  secret: string,
-  method: SignEncodeMethod,
-  algorithm: SignAlgorithm,
-): Promise<string>
-⋮----
-export function checkWebCryptoAPISupported()
-
-================
-File: src/types/request/futures.ts
-================
-/**==========================================================================================================================
- * FUTURES
- * ==========================================================================================================================
- */
-⋮----
-export interface GetFuturesOrderBookReq {
-  settle: 'btc' | 'usdt' | 'usd';
-  contract: string;
-  interval?: string;
-  limit?: number;
-  with_id?: boolean;
-}
-⋮----
-export interface GetFuturesTradesReq {
-  settle: 'btc' | 'usdt' | 'usd';
-  contract: string;
-  limit?: number;
-  offset?: number;
-  last_id?: string;
-  from?: number;
-  to?: number;
-}
-⋮----
-export interface GetFuturesCandlesReq {
-  settle: 'btc' | 'usdt' | 'usd';
-  contract: string;
-  from?: number;
-  to?: number;
-  limit?: number;
-  interval?: string;
-}
-⋮----
-export interface GetFuturesStatsReq {
-  settle: 'btc' | 'usdt' | 'usd';
-  contract: string;
-  from?: number;
-  interval?: string;
-  limit?: number;
-}
-⋮----
-export interface GetFundingRatesReq {
-  settle: 'btc' | 'usdt' | 'usd';
-  contract: string;
-  limit?: number;
-  from?: number;
-  to?: number;
-}
-⋮----
-export interface GetLiquidationHistoryReq {
-  settle: 'btc' | 'usdt' | 'usd';
-  contract?: string;
-  from?: number;
-  to?: number;
-  limit?: number;
-}
-⋮----
-export interface GetRiskLimitTiersReq {
-  settle: 'btc' | 'usdt' | 'usd';
-  contract: string;
-  limit?: number;
-  offset?: number;
-}
-⋮----
-export interface GetRiskLimitTableReq {
-  settle: 'btc' | 'usdt' | 'usd';
-  table_id: string;
-}
-⋮----
-export interface GetFuturesAccountBookReq {
-  settle: 'btc' | 'usdt' | 'usd';
-  contract?: string;
-  limit?: number;
-  offset?: number;
-  from?: number;
-  to?: number;
-  type?:
-    | 'dnw'
-    | 'pnl'
-    | 'fee'
-    | 'refr'
-    | 'fund'
-    | 'point_dnw'
-    | 'point_fee'
-    | 'point_refr'
-    | 'bonus_offset';
-}
-⋮----
-export interface GetFuturesPositionsReq {
-  settle: 'btc' | 'usdt' | 'usd';
-  holding?: boolean;
-  limit?: number;
-  offset?: number;
-  position_side?: string; // v4.105.3: Add position_side parameter for hedge mode support
-  hedge_mode?: boolean; // v4.104.3: Add hedge_mode parameter
-}
-⋮----
-position_side?: string; // v4.105.3: Add position_side parameter for hedge mode support
-hedge_mode?: boolean; // v4.104.3: Add hedge_mode parameter
-⋮----
-export interface UpdateDualModePositionMarginReq {
-  settle: 'btc' | 'usdt' | 'usd';
-  contract: string;
-  change: string;
-  dual_side: 'dual_long' | 'dual_short';
-}
-⋮----
-export interface UpdateDualModePositionLeverageReq {
-  settle: 'btc' | 'usdt' | 'usd';
-  contract: string;
-  leverage: string;
-  cross_leverage_limit?: string;
-}
-⋮----
-export interface SubmitFuturesOrderReq {
-  xGateExptime?: number;
-  settle: 'btc' | 'usdt' | 'usd';
-  contract: string;
-  size: number;
-  iceberg?: number;
-  price?: string;
-  close?: boolean;
-  reduce_only?: boolean;
-  tif?: string;
-  text?: string;
-  auto_size?: string;
-  stp_act?: string;
-}
-⋮----
-export interface GetFuturesOrdersReq {
-  settle: 'btc' | 'usdt' | 'usd';
-  contract?: string;
-  status: string;
-  limit?: number;
-  offset?: number;
-  last_id?: string;
-}
-⋮----
-export interface DeleteAllFuturesOrdersReq {
-  xGateExptime?: number;
-  settle: 'btc' | 'usdt' | 'usd';
-  contract: string;
-  side?: string;
-}
-⋮----
-export interface GetFuturesOrdersByTimeRangeReq {
-  settle: 'btc' | 'usdt' | 'usd';
-  contract?: string;
-  from?: number;
-  to?: number;
-  limit?: number;
-  offset?: number;
-}
-⋮----
-export interface UpdateFuturesOrderReq {
-  xGateExptime?: number;
-  settle: 'btc' | 'usdt' | 'usd';
-  order_id: string;
-  size?: number;
-  price?: string;
-  amend_text?: string;
-}
-⋮----
-export interface GetFuturesTradingHistoryReq {
-  settle: 'btc' | 'usdt' | 'usd';
-  contract?: string;
-  order?: number;
-  limit?: number;
-  offset?: number;
-  last_id?: string;
-}
-⋮----
-export interface GetFuturesTradingHistoryByTimeRangeReq {
-  settle: 'btc' | 'usdt' | 'usd';
-  contract?: string;
-  from?: number;
-  to?: number;
-  limit?: number;
-  offset?: number;
-  role?: 'maker' | 'taker';
-}
-⋮----
-export interface GetFuturesPositionHistoryReq {
-  settle: 'btc' | 'usdt' | 'usd';
-  contract?: string;
-  limit?: number;
-  offset?: number;
-  from?: number;
-  to?: number;
-  side?: 'long' | 'short';
-  pnl?: string;
-}
-⋮----
-export interface GetFuturesLiquidationHistoryReq {
-  settle: 'btc' | 'usdt' | 'usd';
-  contract?: string;
-  limit?: number;
-  at?: number;
-}
-⋮----
-export interface SubmitFuturesTriggeredOrderReq {
-  initial: {
-    contract: string;
-    size?: number;
-    price?: string;
-    close?: boolean;
-    tif?: 'gtc' | 'ioc';
-    text?: string;
-    reduce_only?: boolean;
-    auto_size?: string;
-  };
-  trigger: {
-    strategy_type?: 0 | 1;
-    price_type?: 0 | 1 | 2;
-    price?: string;
-    rule?: 1 | 2;
-    expiration?: number;
-  };
-  order_type?:
-    | 'close-long-order'
-    | 'close-short-order'
-    | 'close-long-position'
-    | 'close-short-position'
-    | 'plan-close-long-position'
-    | 'plan-close-short-position';
-  settle: 'btc' | 'usdt' | 'usd';
-}
-⋮----
-export interface GetFuturesAutoOrdersReq {
-  settle: 'btc' | 'usdt' | 'usd';
-  status: 'open' | 'finished';
-  contract?: string;
-  limit?: number;
-  offset?: number;
-}
-⋮----
-/**
- * Modify contract order parameters
- */
-export interface BatchAmendOrderReq {
-  order_id?: number; // Order id, order_id and text must contain at least one
-  text?: string; // User-defined order text, at least one of order_id and text must be passed
-  size?: number; // The new order size, including the executed order size
-  price?: string; // New order price
-  amend_text?: string; // Custom info during amending order
-}
-⋮----
-order_id?: number; // Order id, order_id and text must contain at least one
-text?: string; // User-defined order text, at least one of order_id and text must be passed
-size?: number; // The new order size, including the executed order size
-price?: string; // New order price
-amend_text?: string; // Custom info during amending order
-⋮----
-// v4.105.8: New GET /futures/{settle}/position_close_history endpoint request
-export interface GetFuturesPositionCloseHistoryReq {
-  settle: 'btc' | 'usdt' | 'usd';
-  contract?: string;
-  limit?: number;
-  offset?: number;
-  from?: number;
-  to?: number;
-}
-⋮----
-// v4.104.6: New GET /futures/{settle}/insurance endpoint request
-export interface GetFuturesInsuranceReq {
-  settle: 'btc' | 'usdt' | 'usd';
-  limit?: number;
-}
 
 ================
 File: src/types/request/unified.ts
@@ -3782,6 +3546,149 @@ export interface SubmitMainSubTransferReq {
   amount: string;
   client_order_id?: string;
   sub_account_type?: 'spot' | 'futures' | 'cross_margin' | 'delivery';
+}
+
+================
+File: src/types/request/withdrawal.ts
+================
+/**================================================================================================================================
+ * WITHDRAW
+ * ==========================================================================================================================
+ */
+⋮----
+export interface SubmitWithdrawalReq {
+  amount: string;
+  currency: string;
+  chain: string;
+  withdraw_order_id?: string;
+  address?: string;
+  memo?: string;
+}
+
+================
+File: src/types/response/account.ts
+================
+/**==========================================================================================================================
+ * ACCOUNT
+ * ==========================================================================================================================
+ */
+⋮----
+export interface AccountDetail {
+  user_id: number;
+  ip_whitelist: string[];
+  currency_pairs: string[];
+  key: {
+    mode: number;
+  };
+  tier: number;
+  copy_trading_role: number;
+}
+⋮----
+export interface AccountRateLimit {
+  type: string;
+  tier: string;
+  ratio: string;
+  main_ratio: string;
+  updated_at: string;
+}
+⋮----
+export interface StpGroup {
+  id: number;
+  name: string;
+  creator_id: number;
+  create_time: number;
+}
+⋮----
+export interface StpGroupUser {
+  user_id: number;
+  stp_id: number;
+  create_time: number;
+}
+⋮----
+export interface AccountMainKey {
+  state: number; // 1 - Normal, 2 - Locked, 3 - Frozen
+  mode: number; // 1 - Classic, 2 - Legacy Unified
+  name: string;
+  currency_pairs: string[];
+  user_id: number;
+  ip_whitelist: string[];
+  perms: {
+    name: string;
+    read_only: boolean;
+  }[];
+  key: string;
+  created_at: string;
+  updated_at: string;
+  last_access: string;
+}
+⋮----
+state: number; // 1 - Normal, 2 - Locked, 3 - Frozen
+mode: number; // 1 - Classic, 2 - Legacy Unified
+
+================
+File: src/types/response/collateralloan.ts
+================
+/**==========================================================================================================================
+ * COLLATERAL LOAN
+ * ==========================================================================================================================
+ */
+⋮----
+export interface LoanOrder {
+  order_id: number;
+  collateral_currency: string;
+  collateral_amount: string;
+  borrow_currency: string;
+  borrow_amount: string;
+  repaid_amount: string;
+  repaid_principal: string;
+  repaid_interest: string;
+  init_ltv: string;
+  current_ltv: string;
+  liquidate_ltv: string;
+  status: string;
+  borrow_time: number;
+  left_repay_total: string;
+  left_repay_principal: string;
+  left_repay_interest: string;
+}
+⋮----
+export interface LoanRepaymentHistoryRecord {
+  order_id: number;
+  record_id: number;
+  repaid_amount: string;
+  borrow_currency: string;
+  collateral_currency: string;
+  init_ltv: string;
+  borrow_time: number;
+  repay_time: number;
+  total_interest: string;
+  before_left_principal: string;
+  after_left_principal: string;
+  before_left_collateral: string;
+  after_left_collateral: string;
+}
+⋮----
+export interface LoanCollateralRecord {
+  order_id: number;
+  record_id: number;
+  borrow_currency: string;
+  borrow_amount: string;
+  collateral_currency: string;
+  before_collateral: string;
+  after_collateral: string;
+  before_ltv: string;
+  after_ltv: string;
+  operate_time: number;
+}
+⋮----
+export interface LoanCollateralRatio {
+  collateral_currency: string;
+  borrow_currency: string;
+  init_ltv: string;
+  alert_ltv: string;
+  liquidate_ltv: string;
+  min_borrow_amount: string;
+  left_borrowable_amount: string;
 }
 
 ================
@@ -4027,1183 +3934,90 @@ export interface StructuredProductOrder {
 }
 
 ================
-File: src/types/response/margin.ts
+File: src/types/response/earnuni.ts
 ================
 /**==========================================================================================================================
- * MARGIN
+ * EARN UNI
  * ==========================================================================================================================
  */
 ⋮----
-export interface MarginAccount {
-  currency_pair: string;
-  locked: boolean;
-  risk: string;
-  base: {
-    currency: string;
-    available: string;
-    locked: string;
-    borrowed: string;
-    interest: string;
-  };
-  quote: {
-    currency: string;
-    available: string;
-    locked: string;
-    borrowed: string;
-    interest: string;
-  };
-}
-⋮----
-export interface MarginBalanceHistoryRecord {
-  id: string;
-  time: string;
-  time_ms: number;
+export interface LendingCurrency {
   currency: string;
-  currency_pair: string;
-  change: string;
-  balance: string;
-  type: string;
+  min_lend_amount: string;
+  max_lend_amount: string;
+  max_rate: string;
+  min_rate: string;
 }
 ⋮----
-export interface CrossMarginCurrency {
-  name: string;
-  rate: string;
-  prec: string;
-  discount: string;
-  min_borrow_amount: string;
-  user_max_borrow_amount: string;
-  total_max_borrow_amount: string;
-  price: string;
-  loanable: boolean;
-  status: number;
-}
-⋮----
-export interface CrossMarginAccount {
-  user_id: number;
-  refresh_time: number;
-  locked: boolean;
-  balances: {
-    [currency: string]: {
-      available: string;
-      freeze: string;
-      borrowed: string;
-      interest: string;
-      negative_liab: string;
-      futures_pos_liab: string;
-      equity: string;
-      total_freeze: string;
-      total_liab: string;
-    };
-  };
-  total: string;
-  borrowed: string;
-  interest: string;
-  risk: string;
-  total_initial_margin: string;
-  total_margin_balance: string;
-  total_maintenance_margin: string;
-  total_initial_margin_rate: string;
-  total_maintenance_margin_rate: string;
-  total_available_margin: string;
-  portfolio_margin_total: string;
-  portfolio_margin_total_liab: string;
-  portfolio_margin_total_equity: string;
-}
-⋮----
-export interface CrossMarginAccountHistoryRecord {
-  id: string;
-  time: number;
+export interface LendingOrder {
   currency: string;
-  change: string;
-  balance: string;
-  type: string;
-}
-⋮----
-export interface CrossMarginMorrowLoanRecord {
-  id: string;
-  create_time: number;
-  update_time: number;
-  currency: string;
+  current_amount: string;
   amount: string;
-  text?: string;
-  status: number;
-  repaid: string;
-  repaid_interest: string;
-  unpaid_interest: string;
-}
-⋮----
-export interface MarginUserAccount {
-  currency_pair: string;
-  account_type: string;
-  leverage: string;
-  locked: boolean;
-  risk?: string;
-  mmr?: string;
-  base: {
-    currency: string;
-    available: string;
-    locked: string;
-    borrowed: string;
-    interest: string;
-  };
-  quote: {
-    currency: string;
-    available: string;
-    locked: string;
-    borrowed: string;
-    interest: string;
-  };
-}
-
-================
-File: src/types/response/rebate.ts
-================
-export interface AgencyTransactionHistoryRecord {
-  transaction_time: number;
-  user_id: number;
-  group_name: string;
-  fee: string;
-  fee_asset: string;
-  currency_pair: string;
-  amount: string;
-  amount_asset: string;
-  source: string;
-}
-⋮----
-export interface AgencyCommissionHistoryRecord {
-  commission_time: number;
-  user_id: number;
-  group_name: string;
-  commission_amount: string;
-  commission_asset: string;
-  source: string;
-}
-⋮----
-export interface PartnerSubordinate {
-  user_id: number;
-  user_join_time: number;
-  type: number;
-  desc: string;
-}
-⋮----
-export interface BrokerCommissionHistoryRecord {
-  commission_time: number;
-  user_id: number;
-  group_name: string;
-  amount: string;
-  fee: string;
-  fee_asset: string;
-  rebate_fee: string;
-  source: string;
-  currency_pair: string;
-  sub_broker_info: {
-    user_id: number;
-    original_commission_rate: string;
-    relative_commission_rate: string;
-    commission_rate: string;
-  };
-}
-⋮----
-export interface BrokerTransactionHistoryRecord {
-  transaction_time: number;
-  user_id: number;
-  group_name: string;
-  fee: string;
-  currency_pair: string;
-  amount: string;
-  fee_asset: string;
-  source: string;
-  sub_broker_info: {
-    user_id: number;
-    original_commission_rate: string;
-    relative_commission_rate: string;
-    commission_rate: string;
-  };
-}
-⋮----
-export interface PartnerCommission {
-  commission_time: number;
-  user_id: number;
-  group_name: string;
-  commission_amount: string;
-  commission_asset: string;
-  source: string;
-}
-⋮----
-export interface PartnerTransaction {
-  transaction_time: number;
-  user_id: number;
-  group_name: string;
-  fee: string;
-  fee_asset: string;
-  currency_pair: string;
-  amount: string;
-  amount_asset: string;
-  source: string;
-}
-
-================
-File: src/index.ts
-================
-// Request Types
-⋮----
-// Response Types
-⋮----
-// Websockets Types
-⋮----
-// Shared Types
-
-================
-File: .gitignore
-================
-!.gitkeep
-.DS_STORE
-*.log
-npm-debug.log*
-yarn-debug.log*
-yarn-error.log*
-lerna-debug.log*
-report.[0-9]*.[0-9]*.[0-9]*.[0-9]*.json
-pids
-*.pid
-*.seed
-*.pid.lock
-node_modules/
-.npm
-.eslintcache
-.node_repl_history
-*.tgz
-.yarn-integrity
-.env
-.env.test
-.cache
-bundleReport.html
-.history/
-dist
-coverage
-localtest.sh
-repomix.sh
-
-ws-private-spot-wsapi-performance.ts
-ws-private-perp-futures-wsapi-readonly.ts
-privatetest.ts
-
-privaterepotracker
-restClientRegex.ts
-
-testfile.ts
-
-================
-File: .nvmrc
-================
-v22.17.0
-
-================
-File: tsconfig.json
-================
-{
-  "compilerOptions": {
-    "allowSyntheticDefaultImports": true,
-    "baseUrl": ".",
-    "noEmitOnError": true,
-    "declaration": true,
-    "esModuleInterop": true,
-    "forceConsistentCasingInFileNames": false,
-    "inlineSourceMap": false,
-    "lib": ["esnext"],
-    "listEmittedFiles": false,
-    "listFiles": false,
-    "moduleResolution": "node",
-    "noFallthroughCasesInSwitch": true,
-    "noImplicitAny": true,
-    "noUnusedParameters": true,
-    "pretty": true,
-    "removeComments": false,
-    "resolveJsonModule": true,
-    "skipLibCheck": false,
-    "sourceMap": true,
-    "strict": true,
-    "strictNullChecks": true,
-    "types": ["node", "jest"],
-    "module": "commonjs",
-    "outDir": "dist/cjs",
-    "target": "esnext"
-  },
-  "compileOnSave": true,
-  "exclude": ["node_modules", "dist"],
-  "include": ["src/**/*.*", "test/**/*.*", ".eslintrc.cjs"]
-}
-
-================
-File: examples/ws-private-spot-wsapi.ts
-================
-/* eslint-disable @typescript-eslint/no-unused-vars */
-⋮----
-import { LogParams, WebsocketClient } from '../src/index.js';
-// import { LogParams, WebsocketClient } from 'gateio-api'; // normally you should install this module via npm: `npm install gateio-api`
-⋮----
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-⋮----
-// Define a custom logger object to handle logging at different levels
-⋮----
-// Trace level logging: used for detailed debugging information
-⋮----
-// Uncomment the line below to enable trace logging
-// console.log(new Date(), 'trace', ...params);
-⋮----
-// Info level logging: used for general informational messages
-⋮----
-// Error level logging: used for error messages
-⋮----
-async function start()
-⋮----
-// See comments below about event-driven vs promise-driven. Not needed if using the promise-driven approach
-// client.on('update', (data) => {
-//   // console.info(new Date(), 'ws data received: ', JSON.stringify(data));
-//   console.info(new Date(), 'ws data received: ', JSON.stringify(data, null, 2));
-// });
-⋮----
-// Something happened, attempting to reconnect
-⋮----
-// Reconnect successful
-⋮----
-// Connection closed. If unexpected, expect reconnect -> reconnected.
-⋮----
-// Reply to a request, e.g. "subscribe"/"unsubscribe"/"authenticate"
-// See comments below about event-driven vs promise-driven. Not needed if using the promise-driven approach
-// client.on('response', (data) => {
-//   console.info(
-//     new Date(),
-//     'ws server reply ',
-//     JSON.stringify(data, null, 2),
-//     '\n',
-//   );
-// });
-⋮----
-// Optional, listen to this event if you prefer the event-driven approach.
-// See below comments on event-driven vs promise-driven.
-// client.on('authenticated', (data) => {
-//   console.error(new Date(), 'ws authenticated: ', data);
-// });
-⋮----
-/**
-     * All WebSocket API (WS API) messaging should be done via the sendWSAPIRequest method.
-     *
-     * You have two ways to handle responses on the WS API. You can either:
-     * - event-driven: process async `response` and `update` events from the websocket client, OR
-     * - promise-driven: await every call to `client.sendWSAPIRequest`, this can behave similar to using a REST API (successful responses resolve, exceptions reject).
-     */
-⋮----
-/**
-     * No need to authenticate first - the SDK will automatically authenticate for you when you send your first request.
-     *
-     * Unless you want to prepare the connection before your first request, to speed up your first request.
-     */
-⋮----
-/**
-     * For other channels, the 3rd parameter should have any parameters for the request (the payload that goes in req_param in the docs).
-     *
-     * See WsAPIRequestsTopicMap for a topic->parameter map.
-     *
-     * Note that internal parameters such as "signature" etc are all handled automatically by the SDK.
-     */
-⋮----
-/**
-     * Submit spot order
-     */
-⋮----
-/**
-     * Cancel spot order
-     */
-⋮----
-/**
-     * Batch cancel spot order
-     */
-⋮----
-/**
-     * Amend/Update spot order
-     */
-⋮----
-/**
-     * Get spot order status
-     */
-⋮----
-/**
-     * If you don't want to use await (and prefer the async event emitter), make sure to still include a catch block.
-     *
-     * The response will come async via the event emitter in the WS Client.
-     */
-⋮----
-// client
-//   .sendWSAPIRequest('spotV4', 'spot.order_status', {
-//     order_id: '600995435390',
-//     currency_pair: 'BTC_USDT',
-//   })
-//   .catch((e) => {
-//     console.error(`exception ws api call, get spot order status: `, e);
-//   });
-
-================
-File: src/types/response/unified.ts
-================
-export interface UnifiedAccountInfo {
-  user_id: number;
-  refresh_time: number;
-  locked: boolean;
-  balances: {
-    [key: string]: {
-      available: string;
-      freeze: string;
-      borrowed: string;
-      negative_liab: string;
-      futures_pos_liab: string;
-      equity: string;
-      total_freeze: string;
-      total_liab: string;
-      spot_in_use: string;
-      funding: string;
-      funding_version: string;
-      cross_balance: string;
-      iso_balance: string;
-      im: string;
-      mm: string;
-      mmr: string;
-      margin_balance: string;
-      available_margin: string;
-      imr?: string;
-      enabled_collateral?: boolean;
-    };
-  };
-  total: string;
-  borrowed: string;
-  total_initial_margin: string;
-  total_margin_balance: string;
-  total_maintenance_margin: string;
-  total_initial_margin_rate: string;
-  total_maintenance_margin_rate: string;
-  total_available_margin: string;
-  unified_account_total: string;
-  unified_account_total_liab: string;
-  unified_account_total_equity: string;
-  leverage: string;
-  spot_order_loss: string;
-  spot_hedge: boolean;
-  margin_mode?: string;
-  total_balance?: string;
-  cross_leverage?: string;
-  portfolio_margin?: string;
-  risk_level?: string;
-  is_all_collateral?: boolean;
-  borrow_amount?: string;
-  cross_margin_leverage?: string;
-  use_funding?: boolean;
-}
-⋮----
-export interface UnifiedLoan {
-  currency: string;
-  currency_pair: string;
-  amount: string;
-  type: 'platform' | 'margin';
+  lent_amount: string;
+  frozen_amount: string;
+  min_rate: string;
+  interest_status: string;
+  reinvest_left_amount: string;
   create_time: number;
   update_time: number;
 }
 ⋮----
-export interface UnifiedLoanRecord {
-  id: number;
-  type: 'borrow' | 'repay';
-  repayment_type: 'none' | 'manual_repay' | 'auto_repay' | 'cancel_auto_repay';
-  currency_pair: string;
+export interface LendingRecord {
   currency: string;
   amount: string;
+  last_wallet_amount: string;
+  last_lent_amount: string;
+  last_frozen_amount: string;
+  type: 'lend' | 'redeem';
   create_time: number;
-  borrow_type: string;
 }
-export interface UnifiedInterestRecord {
+⋮----
+export interface LendingInterestRecord {
+  status: number;
   currency: string;
-  currency_pair: string;
   actual_rate: string;
   interest: string;
-  status: number;
-  type: 'platform' | 'margin';
+  interest_status: string;
   create_time: number;
 }
-⋮----
-export interface UnifiedRiskUnitDetails {
-  user_id: number;
-  spot_hedge: boolean;
-  risk_units: {
-    symbol: string;
-    spot_in_use: string;
-    maintain_margin: string;
-    initial_margin: string;
-    delta: string;
-    gamma: string;
-    theta: string;
-    vega: string;
-  }[];
-}
-⋮----
-export interface UnifiedCurrencyDiscountTiers {
-  currency: string;
-  discount_tiers: {
-    tier: string;
-    discount: string;
-    lower_limit: string;
-    upper_limit: string;
-    leverage: string;
-  }[];
-}
-⋮----
-export interface UserCurrencyLeverageConfig {
-  current_leverage: string;
-  min_leverage: string;
-  max_leverage: string;
-  debit: string;
-  available_margin: string;
-  borrowable: string;
-  except_leverage_borrowable: string;
-}
-⋮----
-export interface UnifiedLoanCurrency {
-  name: string;
-  prec: string;
-  min_borrow_amount: string;
-  user_max_borrow_amount: string;
-  total_max_borrow_amount: string;
-  loan_status: string;
-}
-⋮----
-export interface UnifiedHistoryLendingRate {
-  currency: string;
-  tier: string;
-  tier_up_rate: string;
-  rates: {
-    time: number;
-    rate: string;
-  }[];
-}
-⋮----
-export interface MarginTier {
-  tier: string;
-  margin_rate: string;
-  lower_limit: string;
-  upper_limit: string;
-}
-⋮----
-export interface PortfolioMarginCalculation {
-  maintain_margin_total: string;
-  initial_margin_total: string;
-  calculate_time: number;
-  risk_unit: {
-    symbol: string;
-    spot_in_use: string;
-    maintain_margin: string;
-    initial_margin: string;
-    margin_result: {
-      type:
-        | 'original_position'
-        | 'long_delta_original_position'
-        | 'short_delta_original_position';
-      profit_loss_ranges: {
-        price_percentage: string;
-        implied_volatility_percentage: string;
-        profit_loss: string;
-      }[];
-      max_loss: {
-        price_percentage: string;
-        implied_volatility_percentage: string;
-        profit_loss: string;
-      };
-      mr1: string;
-      mr2: string;
-      mr3: string;
-      mr4: string;
-      delta: string;
-      gamma: string;
-      theta: string;
-      vega: string;
-    }[];
-  }[];
-}
-⋮----
-export interface UnifiedCollateralCurrenciesResp {
-  is_success: boolean;
-}
 
 ================
-File: .eslintrc.cjs
-================
-// 'no-unused-vars': ['warn'],
-
-================
-File: src/lib/websocket/websocket-util.ts
-================
-import WebSocket from 'isomorphic-ws';
-⋮----
-import { WSAPIRequest } from '../../types/websockets/requests.js';
-import {
-  FuturesWSAPITopic,
-  SpotWSAPITopic,
-} from '../../types/websockets/wsAPI.js';
-⋮----
-/**
- * Should be one WS key per unique URL. Some URLs may need a suffix.
- */
-⋮----
-/**
-   * Spot & Margin
-   * https://www.gate.io/docs/developers/apiv4/ws/en/
-   */
-⋮----
-/**
-   * Perpetual futures (USDT)
-   * https://www.gate.io/docs/developers/futures/ws/en/#gate-io-futures-websocket-v4
-   */
-⋮----
-/**
-   * Perpetual futures (BTC)
-   * https://www.gate.io/docs/developers/futures/ws/en/#gate-io-futures-websocket-v4
-   */
-⋮----
-/**
-   * Delivery Futures (USDT)
-   * https://www.gate.io/docs/developers/delivery/ws/en/
-   */
-⋮----
-/**
-   * Delivery Futures (BTC)
-   * https://www.gate.io/docs/developers/delivery/ws/en/
-   */
-⋮----
-/**
-   * Options
-   * https://www.gate.io/docs/developers/options/ws/en/
-   */
-⋮----
-/**
-   * Announcements V4
-   * https://www.gate.io/docs/developers/options/ws/en/
-   */
-⋮----
-/** This is used to differentiate between each of the available websocket streams */
-export type WsKey = (typeof WS_KEY_MAP)[keyof typeof WS_KEY_MAP];
-⋮----
-export type FuturesWsKey =
-  | typeof WS_KEY_MAP.perpFuturesUSDTV4
-  | typeof WS_KEY_MAP.perpFuturesBTCV4
-  | typeof WS_KEY_MAP.deliveryFuturesUSDTV4
-  | typeof WS_KEY_MAP.deliveryFuturesBTCV4;
-⋮----
-export type WsMarket = 'all';
-⋮----
-/**
- * Normalised internal format for a request (subscribe/unsubscribe/etc) on a topic, with optional parameters.
- *
- * - Topic: the topic this event is for
- * - Payload: the parameters to include, optional. E.g. auth requires key + sign. Some topics allow configurable parameters.
- */
-export interface WsTopicRequest<
-  TWSTopic extends string = string,
-  TWSPayload = any,
-> {
-  topic: TWSTopic;
-  payload?: TWSPayload;
-}
-⋮----
-/**
- * Conveniently allow users to request a topic either as string topics or objects (containing string topic + params)
- */
-export type WsTopicRequestOrStringTopic<
-  TWSTopic extends string,
-  TWSPayload = any,
-> = WsTopicRequest<TWSTopic, TWSPayload> | string;
-⋮----
-/**
- * Some exchanges have two livenet environments, some have test environments, some dont. This allows easy flexibility for different exchanges.
- * Examples:
- *  - One livenet and one testnet: NetworkMap<'livenet' | 'testnet'>
- *  - One livenet, sometimes two, one testnet: NetworkMap<'livenet' | 'testnet', 'livenet2'>
- *  - Only one livenet, no other networks: NetworkMap<'livenet'>
- */
-type NetworkMap<
-  TRequiredKeys extends string,
-  TOptionalKeys extends string | undefined = undefined,
-> = Record<TRequiredKeys, string> &
-  (TOptionalKeys extends string
-    ? Record<TOptionalKeys, string | undefined>
-    : Record<TRequiredKeys, string>);
-⋮----
-export function neverGuard(x: never, msg: string): Error
-⋮----
-/**
- * WS API promises are stored using a primary key. This key is constructed using
- * properties found in every request & reply.
- */
-export function getPromiseRefForWSAPIRequest(
-  requestEvent: WSAPIRequest,
-): string
-⋮----
-export function getPrivateSpotTopics(): string[]
-⋮----
-// Consumeable channels for spot
-⋮----
-// WebSocket API for spot
-⋮----
-export function getPrivateFuturesTopics(): string[]
-⋮----
-// These are the same for perps vs delivery futures
-⋮----
-export function getPrivateOptionsTopics(): string[]
-⋮----
-/**
- * ws.terminate() is undefined in browsers.
- * This only works in node.js, not in browsers.
- * Does nothing if `ws` is undefined. Does nothing in browsers.
- */
-export function safeTerminateWs(
-  ws?: WebSocket | any,
-  fallbackToClose?: boolean,
-): boolean
-
-================
-File: src/types/shared.ts
-================
-export type GateBaseUrlKey =
-  | 'live'
-  | 'futuresLiveAlternative'
-  | 'futuresTestnet';
-⋮----
-// interfaces
-⋮----
-export interface FromToPageLimit {
-  from: number;
-  to: number;
-  page: number;
-  limit: number;
-}
-⋮----
-// Used for spot and flash swap
-export interface CurrencyPair {
-  id?: string;
-  base?: string;
-  base_name?: string;
-  quote?: string;
-  quote_name?: string;
-  fee?: string;
-  min_base_amount?: string;
-  min_quote_amount?: string;
-  max_base_amount?: string;
-  max_quote_amount?: string;
-  amount_precision?: number;
-  precision?: number;
-  trade_status?: 'untradable' | 'buyable' | 'sellable' | 'tradable';
-  sell_start?: number;
-  buy_start?: number;
-  type: string;
-  delisting_time?: number;
-  trade_url?: string;
-}
-
-================
-File: src/lib/BaseRestClient.ts
-================
-import axios, { AxiosRequestConfig, AxiosResponse, Method } from 'axios';
-import https from 'https';
-⋮----
-import { neverGuard } from './misc-util.js';
-import {
-  CHANNEL_ID,
-  getRestBaseUrl,
-  RestClientOptions,
-  serializeParams,
-} from './requestUtils.js';
-import {
-  checkWebCryptoAPISupported,
-  hashMessage,
-  SignAlgorithm,
-  SignEncodeMethod,
-  signMessage,
-} from './webCryptoAPI.js';
-⋮----
-/**
- * Used to switch how authentication/requests work under the hood
- */
-⋮----
-export type RestClientType =
-  (typeof REST_CLIENT_TYPE_ENUM)[keyof typeof REST_CLIENT_TYPE_ENUM];
-⋮----
-interface SignedRequest<T extends object | undefined = {}> {
-  originalParams: T;
-  paramsWithSign?: T & { sign: string };
-  serializedParams: string;
-  sign: string;
-  queryParamsWithSign: string;
-  timestamp: number;
-  recvWindow: number;
-}
-⋮----
-interface UnsignedRequest<T extends object | undefined = {}> {
-  originalParams: T;
-  paramsWithSign: T;
-}
-⋮----
-type SignMethod = 'gateV4';
-⋮----
-/**
- * Some requests require some params to be in the query string and some in the body. Some even support passing params via headers.
- * This type anticipates these are possible in any combination.
- *
- * The request builder will automatically handle where parameters should go.
- */
-type ParamsInQueryBodyOrHeader = {
-  query?: object;
-  body?: object;
-  headers?: object;
-};
-⋮----
-/**
- * Enables:
- * - Detailed request/response logging
- * - Full request dump in any exceptions thrown from API responses
- */
-⋮----
-// request: {
-//   url: response.config.url,
-//   method: response.config.method,
-//   data: response.config.data,
-//   headers: response.config.headers,
-// },
-⋮----
-/**
- * Impure, mutates params to remove any values that have a key but are undefined.
- */
-function deleteUndefinedValues(params?: any): void
-⋮----
-export abstract class BaseRestClient
-⋮----
-/** Defines the client type (affecting how requests & signatures behave) */
-abstract getClientType(): RestClientType;
-⋮----
-/**
-   * Create an instance of the REST client. Pass API credentials in the object in the first parameter.
-   * @param {RestClientOptions} [restClientOptions={}] options to configure REST API connectivity
-   * @param {AxiosRequestConfig} [networkOptions={}] HTTP networking options for axios
-   */
-constructor(
-    restClientOptions: RestClientOptions = {},
-    networkOptions: AxiosRequestConfig = {},
-)
-⋮----
-/** Throw errors if any request params are empty */
-⋮----
-/** in ms == 5 minutes by default */
-⋮----
-/** inject custom rquest options based on axios specs - see axios docs for more guidance on AxiosRequestConfig: https://github.com/axios/axios#request-config */
-⋮----
-// If enabled, configure a https agent with keepAlive enabled
-⋮----
-// Extract existing https agent parameters, if provided, to prevent the keepAlive flag from overwriting an existing https agent completely
-⋮----
-// For more advanced configuration, raise an issue on GitHub or use the "networkOptions"
-// parameter to define a custom httpsAgent with the desired properties
-⋮----
-// Check Web Crypto API support when credentials are provided and no custom sign function is used
-⋮----
-// Throw if one of the 3 values is missing, but at least one of them is set
-⋮----
-/**
-   * Timestamp used to sign the request. Override this method to implement your own timestamp/sync mechanism
-   */
-getSignTimestampMs(): number
-⋮----
-protected get(endpoint: string, params?: object)
-⋮----
-// GET only supports params in the query string
-⋮----
-protected post(endpoint: string, params?: ParamsInQueryBodyOrHeader)
-⋮----
-protected getPrivate(endpoint: string, params?: object)
-⋮----
-// GET only supports params in the query string
-⋮----
-protected postPrivate(endpoint: string, params?: ParamsInQueryBodyOrHeader)
-⋮----
-protected deletePrivate(
-    endpoint: string,
-    params?: ParamsInQueryBodyOrHeader,
-)
-⋮----
-protected putPrivate(endpoint: string, params?: ParamsInQueryBodyOrHeader)
-⋮----
-// protected patchPrivate(endpoint: string, params?: any) {
-protected patchPrivate(endpoint: string, params?: ParamsInQueryBodyOrHeader)
-⋮----
-/**
-   * @private Make a HTTP request to a specific endpoint. Private endpoint API calls are automatically signed.
-   */
-private async _call(
-    method: Method,
-    endpoint: string,
-    params?: ParamsInQueryBodyOrHeader,
-    isPublicApi?: boolean,
-): Promise<any>
-⋮----
-// Sanity check to make sure it's only ever prefixed by one forward slash
-⋮----
-// Build a request and handle signature process
-⋮----
-// Dispatch request
-⋮----
-// See: https://www.gate.io/docs/developers/apiv4/en/#return-format
-⋮----
-// Throw API rejections by parsing the response code from the body
-⋮----
-/**
-   * @private generic handler to parse request exceptions
-   */
-parseException(e: any, request: AxiosRequestConfig<any>): unknown
-⋮----
-// Something happened in setting up the request that triggered an error
-⋮----
-// request made but no response received
-⋮----
-// The request was made and the server responded with a status code
-// that falls out of the range of 2xx
-⋮----
-// console.error('err: ', response?.data);
-⋮----
-// Prevent credentials from leaking into error messages
-⋮----
-/**
-   * @private sign request and set recv window
-   */
-private async signRequest<
-    T extends ParamsInQueryBodyOrHeader | undefined = {},
-  >(
-    data: T,
-    endpoint: string,
-    method: Method,
-    signMethod: SignMethod,
-): Promise<SignedRequest<T>>
-⋮----
-const timestamp = +(this.getSignTimestampMs() / 1000).toFixed(0); // in seconds
-⋮----
-// recvWindow: this.options.recvWindow,
-⋮----
-// It's possible to override the recv window on a per rquest level
-⋮----
-// console.log('sign params: ', {
-//   requestBodyToHash,
-//   paramsStr: toSign,
-//   url: this.baseUrl,
-//   urlPath: this.baseUrlPath,
-// });
-⋮----
-private async signMessage(
-    paramsStr: string,
-    secret: string,
-    method: 'hex' | 'base64',
-    algorithm: SignAlgorithm,
-): Promise<string>
-⋮----
-private async prepareSignParams<
-    TParams extends ParamsInQueryBodyOrHeader | undefined,
-  >(
-    method: Method,
-    endpoint: string,
-    signMethod: SignMethod,
-    params?: TParams,
-    isPublicApi?: true,
-  ): Promise<UnsignedRequest<TParams>>;
-⋮----
-private async prepareSignParams<
-    TParams extends ParamsInQueryBodyOrHeader | undefined,
-  >(
-    method: Method,
-    endpoint: string,
-    signMethod: SignMethod,
-    params?: TParams,
-    isPublicApi?: false | undefined,
-  ): Promise<SignedRequest<TParams>>;
-⋮----
-private async prepareSignParams<
-    TParams extends ParamsInQueryBodyOrHeader | undefined,
-  >(
-    method: Method,
-    endpoint: string,
-    signMethod: SignMethod,
-    params?: TParams,
-    isPublicApi?: boolean,
-)
-⋮----
-/** Returns an axios request object. Handles signing process automatically if this is a private API call */
-private async buildRequest(
-    method: Method,
-    endpoint: string,
-    url: string,
-    params?: ParamsInQueryBodyOrHeader,
-    isPublicApi?: boolean,
-): Promise<AxiosRequestConfig>
-
-================
-File: src/types/request/spot.ts
+File: src/types/response/flashswap.ts
 ================
 /**==========================================================================================================================
- * SPOT
+ * FLASH SWAP
  * ==========================================================================================================================
  */
 ⋮----
-export interface GetSpotOrderBookReq {
+export interface FlashSwapCurrencyPair {
   currency_pair: string;
-  interval?: string;
-  limit?: number;
-  with_id?: boolean;
+  sell_currency: string;
+  buy_currency: string;
+  sell_min_amount: string;
+  sell_max_amount: string;
+  buy_min_amount: string;
+  buy_max_amount: string;
 }
 ⋮----
-export interface GetSpotTradesReq {
-  currency_pair: string;
-  limit?: number;
-  last_id?: string;
-  reverse?: boolean;
-  from?: number;
-  to?: number;
-  page?: number;
-}
-⋮----
-export interface GetSpotCandlesReq {
-  currency_pair: string;
-  limit?: number;
-  from?: number;
-  to?: number;
-  interval?:
-    | '1s'
-    | '10s'
-    | '1m'
-    | '5m'
-    | '15m'
-    | '30m'
-    | '1h'
-    | '4h'
-    | '8h'
-    | '1d'
-    | '7d'
-    | '30d';
-}
-⋮----
-export interface GetSpotAccountBookReq {
-  currency?: string;
-  from?: number;
-  to?: number;
-  page?: number;
-  limit?: number;
-  type?: string;
-  code?: string;
-}
-⋮----
-export interface SubmitSpotClosePosCrossDisabledReq {
-  text?: string;
-  currency_pair: string;
-  amount: string;
+export interface FlashSwapOrder {
+  id: number;
+  create_time: number;
+  user_id: number;
+  sell_currency: string;
+  sell_amount: string;
+  buy_currency: string;
+  buy_amount: string;
   price: string;
-  action_mode?: 'ACK' | 'RESULT' | 'FULL';
+  status: number;
 }
 ⋮----
-export interface GetSpotOrdersReq {
-  currency_pair: string;
-  status: 'open' | 'finished';
-  page?: number;
-  limit?: number;
-  account?: 'spot' | 'margin' | 'cross_margin' | 'unified';
-  from?: number;
-  to?: number;
-  side?: 'buy' | 'sell';
-}
-⋮----
-export interface CancelSpotBatchOrdersReq {
-  currency_pair: string;
-  id: string;
-  account?: 'cross_margin';
-  action_mode?: 'ACK' | 'RESULT' | 'FULL';
-}
-⋮----
-export interface DeleteSpotOrderReq {
-  order_id: string;
-  currency_pair: string;
-  account?: 'spot' | 'margin' | 'cross_margin' | 'unified';
-  action_mode?: 'ACK' | 'RESULT' | 'FULL';
-  xGateExptime?: number;
-}
-⋮----
-export interface GetSpotOrderReq {
-  order_id: string;
-  currency_pair: string;
-  account?: 'spot' | 'margin' | 'cross_margin' | 'unified';
-}
-⋮----
-export interface GetSpotTradingHistoryReq {
-  currency_pair?: string;
-  limit?: number;
-  page?: number;
-  order_id?: string;
-  account?: 'spot' | 'margin' | 'cross_margin' | 'unified';
-  from?: number;
-  to?: number;
-}
-⋮----
-export interface UpdateSpotBatchOrdersReq {
-  order_id?: string;
-  currency_pair?: string;
-  amount?: string;
-  price?: string;
-  amend_text?: string;
-}
-⋮----
-export interface GetSpotInsuranceHistoryReq {
-  business: 'margin' | 'unified';
-  currency: string;
-  from: number;
-  to: number;
-  page?: number;
-  limit?: number;
-}
-⋮----
-export interface GetSpotAutoOrdersReq {
-  status: 'open' | 'finished';
-  market?: string;
-  account?: 'normal' | 'margin' | 'cross_margin' | 'unified';
-  limit?: number;
-  offset?: number;
-}
-⋮----
-export interface SubmitSpotOrderReq {
-  xGateExptime?: number;
-  side: 'buy' | 'sell';
-  amount: string;
-  text?: string;
-  currency_pair: string;
-  type?: 'limit' | 'market';
-  account?: 'spot' | 'margin' | 'cross_margin' | 'unified';
-  price?: string;
-  time_in_force?: 'gtc' | 'ioc' | 'poc' | 'fok';
-  iceberg?: string;
-  auto_borrow?: boolean;
-  auto_repay?: boolean;
-  stp_act?: string;
-  action_mode?: string;
-  stop_loss?: string;
-  take_profit?: string;
-  post_only?: boolean;
-}
-⋮----
-export interface UpdateSpotOrderReq {
-  xGateExptime?: number;
-  order_id: string;
-  currency_pair: string;
-  account?: 'spot' | 'margin' | 'cross_margin' | 'unified';
-  amount?: string;
-  price?: string;
-  amend_text?: string;
-  action_mode?: 'ACK' | 'RESULT' | 'FULL';
+export interface SubmitFlashSwapOrderPreviewResp {
+  preview_id: string;
+  sell_currency: string;
+  sell_amount: string;
+  buy_currency: string;
+  buy_amount: string;
+  price: string;
 }
 
 ================
@@ -5721,6 +4535,657 @@ export interface FuturesInsuranceHistory {
 }
 
 ================
+File: src/types/response/margin.ts
+================
+/**==========================================================================================================================
+ * MARGIN
+ * ==========================================================================================================================
+ */
+⋮----
+export interface MarginAccount {
+  currency_pair: string;
+  locked: boolean;
+  risk: string;
+  base: {
+    currency: string;
+    available: string;
+    locked: string;
+    borrowed: string;
+    interest: string;
+  };
+  quote: {
+    currency: string;
+    available: string;
+    locked: string;
+    borrowed: string;
+    interest: string;
+  };
+}
+⋮----
+export interface MarginBalanceHistoryRecord {
+  id: string;
+  time: string;
+  time_ms: number;
+  currency: string;
+  currency_pair: string;
+  change: string;
+  balance: string;
+  type: string;
+}
+⋮----
+export interface CrossMarginCurrency {
+  name: string;
+  rate: string;
+  prec: string;
+  discount: string;
+  min_borrow_amount: string;
+  user_max_borrow_amount: string;
+  total_max_borrow_amount: string;
+  price: string;
+  loanable: boolean;
+  status: number;
+}
+⋮----
+export interface CrossMarginAccount {
+  user_id: number;
+  refresh_time: number;
+  locked: boolean;
+  balances: {
+    [currency: string]: {
+      available: string;
+      freeze: string;
+      borrowed: string;
+      interest: string;
+      negative_liab: string;
+      futures_pos_liab: string;
+      equity: string;
+      total_freeze: string;
+      total_liab: string;
+    };
+  };
+  total: string;
+  borrowed: string;
+  interest: string;
+  risk: string;
+  total_initial_margin: string;
+  total_margin_balance: string;
+  total_maintenance_margin: string;
+  total_initial_margin_rate: string;
+  total_maintenance_margin_rate: string;
+  total_available_margin: string;
+  portfolio_margin_total: string;
+  portfolio_margin_total_liab: string;
+  portfolio_margin_total_equity: string;
+}
+⋮----
+export interface CrossMarginAccountHistoryRecord {
+  id: string;
+  time: number;
+  currency: string;
+  change: string;
+  balance: string;
+  type: string;
+}
+⋮----
+export interface CrossMarginMorrowLoanRecord {
+  id: string;
+  create_time: number;
+  update_time: number;
+  currency: string;
+  amount: string;
+  text?: string;
+  status: number;
+  repaid: string;
+  repaid_interest: string;
+  unpaid_interest: string;
+}
+⋮----
+export interface MarginUserAccount {
+  currency_pair: string;
+  account_type: string;
+  leverage: string;
+  locked: boolean;
+  risk?: string;
+  mmr?: string;
+  base: {
+    currency: string;
+    available: string;
+    locked: string;
+    borrowed: string;
+    interest: string;
+  };
+  quote: {
+    currency: string;
+    available: string;
+    locked: string;
+    borrowed: string;
+    interest: string;
+  };
+}
+
+================
+File: src/types/response/marginuni.ts
+================
+/**==========================================================================================================================
+ * MARGIN UNI
+ * ==========================================================================================================================
+ */
+⋮----
+export interface LendingMarket {
+  currency_pair: string;
+  base_min_borrow_amount: string;
+  quote_min_borrow_amount: string;
+  leverage: string;
+}
+⋮----
+export interface MarginUNILoan {
+  currency: string;
+  currency_pair: string;
+  amount: string;
+  type: string;
+  create_time: number;
+  update_time: number;
+}
+⋮----
+export interface MarginUNILoanRecord {
+  type: string;
+  currency_pair: string;
+  currency: string;
+  amount: string;
+  create_time: number;
+}
+⋮----
+export interface MarginUNIInterestRecord {
+  currency: string;
+  currency_pair: string;
+  actual_rate: string;
+  interest: string;
+  status: number;
+  type: string;
+  create_time: number;
+}
+⋮----
+export interface MarginUNIMaxBorrowable {
+  currency: string;
+  currency_pair: string;
+  borrowable: string;
+}
+
+================
+File: src/types/response/multicollateralLoan.ts
+================
+/**==========================================================================================================================
+ * MULTI COLLATERAL LOAN
+ * ==========================================================================================================================
+ */
+⋮----
+export interface MultiLoanOrder {
+  order_id: string;
+  order_type: string;
+  fixed_type: string;
+  fixed_rate: string;
+  expire_time: number;
+  auto_renew: boolean;
+  auto_repay: boolean;
+  current_ltv: string;
+  status: string;
+  borrow_time: number;
+  total_left_repay_usdt: string;
+  total_left_collateral_usdt: string;
+  borrow_currencies: {
+    currency: string;
+    index_price: string;
+    left_repay_principal: string;
+    left_repay_interest: string;
+    left_repay_usdt: string;
+  }[];
+  collateral_currencies: {
+    currency: string;
+    index_price: string;
+    left_collateral: string;
+    left_collateral_usdt: string;
+  }[];
+}
+⋮----
+export interface RepayMultiLoanResp {
+  order_id: number;
+  repaid_currencies: {
+    succeeded: boolean;
+    label?: string;
+    message?: string;
+    currency: string;
+    repaid_principal: string;
+    repaid_interest: string;
+  }[];
+}
+⋮----
+export interface MultiLoanRepayRecord {
+  order_id: number;
+  record_id: number;
+  init_ltv: string;
+  before_ltv: string;
+  after_ltv: string;
+  borrow_time: number;
+  repay_time: number;
+  borrow_currencies: {
+    currency: string;
+    index_price: string;
+    before_amount: string;
+    before_amount_usdt: string;
+    after_amount: string;
+    after_amount_usdt: string;
+  }[];
+  collateral_currencies: {
+    currency: string;
+    index_price: string;
+    before_amount: string;
+    before_amount_usdt: string;
+    after_amount: string;
+    after_amount_usdt: string;
+  }[];
+  repaid_currencies: {
+    currency: string;
+    index_price: string;
+    repaid_amount: string;
+    repaid_principal: string;
+    repaid_interest: string;
+    repaid_amount_usdt: string;
+  }[];
+  total_interest_list: {
+    currency: string;
+    index_price: string;
+    amount: string;
+    amount_usdt: string;
+  }[];
+  left_repay_interest_list: {
+    currency: string;
+    index_price: string;
+    before_amount: string;
+    before_amount_usdt: string;
+    after_amount: string;
+    after_amount_usdt: string;
+  }[];
+}
+⋮----
+export interface UpdateMultiLoanResp {
+  order_id: number;
+  collateral_currencies: {
+    succeeded: boolean;
+    label?: string;
+    message?: string;
+    currency: string;
+    amount: string;
+  }[];
+}
+⋮----
+export interface MultiLoanAdjustmentRecord {
+  order_id: number;
+  record_id: number;
+  before_ltv: string;
+  after_ltv: string;
+  operate_time: number;
+  borrow_currencies: {
+    currency: string;
+    index_price: string;
+    before_amount: string;
+    before_amount_usdt: string;
+    after_amount: string;
+    after_amount_usdt: string;
+  }[];
+  collateral_currencies: {
+    currency: string;
+    index_price: string;
+    before_amount: string;
+    before_amount_usdt: string;
+    after_amount: string;
+    after_amount_usdt: string;
+  }[];
+}
+⋮----
+export interface MultiLoanCurrencyQuota {
+  currency: string;
+  index_price: string;
+  min_quota: string;
+  left_quota: string;
+  left_quote_usdt: string;
+}
+⋮----
+export interface MultiLoanSupportedCurrencies {
+  loan_currencies: {
+    currency: string;
+    price: string;
+  }[];
+  collateral_currencies: {
+    currency: string;
+    index_price: string;
+    discount: string;
+  }[];
+}
+⋮----
+export interface MultiLoanRatio {
+  init_ltv: string;
+  alert_ltv: string;
+  liquidate_ltv: string;
+}
+⋮----
+export interface MultiLoanFixedRate {
+  currency: string;
+  rate_7d: string;
+  rate_30d: string;
+  update_time: number;
+}
+
+================
+File: src/types/response/options.ts
+================
+/**==========================================================================================================================
+ * OPTIONS
+ * ==========================================================================================================================
+ */
+⋮----
+export interface OptionsContract {
+  name: string;
+  tag: string;
+  create_time: number;
+  expiration_time: number;
+  is_call: boolean;
+  strike_price: string;
+  last_price: string;
+  mark_price: string;
+  orderbook_id: number;
+  trade_id: number;
+  trade_size: number;
+  position_size: number;
+  underlying: string;
+  underlying_price: string;
+  multiplier: string;
+  order_price_round: string;
+  mark_price_round: string;
+  maker_fee_rate: string;
+  taker_fee_rate: string;
+  price_limit_fee_rate: string;
+  ref_discount_rate: string;
+  ref_rebate_rate: string;
+  order_price_deviate: string;
+  order_size_min: number;
+  order_size_max: number;
+  orders_limit: number;
+}
+⋮----
+export interface OptionsSettlementHistoryRecord {
+  time: number;
+  contract: string;
+  profit: string;
+  fee: string;
+  strike_price: string;
+  settle_price: string;
+}
+⋮----
+export interface OptionsUserSettlement {
+  time: number;
+  underlying: string;
+  contract: string;
+  strike_price: string;
+  settle_price: string;
+  size: number;
+  settle_profit: string;
+  fee: string;
+  realised_pnl: string;
+}
+⋮----
+export interface OptionsOrderBook {
+  id?: number;
+  current: number;
+  update: number;
+  asks: { p: string; s: number }[];
+  bids: { p: string; s: number }[];
+}
+⋮----
+export interface OptionsTicker {
+  name: string;
+  last_price: string;
+  mark_price: string;
+  index_price: string;
+  ask1_size: number;
+  ask1_price: string;
+  bid1_size: number;
+  bid1_price: string;
+  position_size: number;
+  mark_iv: string;
+  bid_iv: string;
+  ask_iv: string;
+  leverage: string;
+  delta: string;
+  gamma: string;
+  vega: string;
+  theta: string;
+  rho: string;
+}
+⋮----
+export interface OptionsCandle {
+  t: number;
+  v?: number;
+  c: string;
+  h: string;
+  l: string;
+  o: string;
+}
+⋮----
+export interface OptionsUnderlyingCandle {
+  t: number;
+  v?: number;
+  c: string;
+  h: string;
+  l: string;
+  o: string;
+  sum: string;
+}
+⋮----
+export interface OptionsTrade {
+  id: number;
+  create_time: number;
+  create_time_ms: number;
+  contract: string;
+  size: number;
+  price: string;
+  is_internal?: boolean;
+}
+⋮----
+export interface OptionsAccount {
+  user: number;
+  total: string;
+  short_enabled: boolean;
+  unrealised_pnl: string;
+  init_margin: string;
+  maint_margin: string;
+  order_margin: string;
+  available: string;
+  point: string;
+  currency: string;
+}
+export interface OptionsAccountChangeRecord {
+  time: number;
+  change: string;
+  balance: string;
+  type: 'dnw' | 'prem' | 'fee' | 'refr' | 'set';
+  text: string;
+}
+⋮----
+export interface OptionsPositionsUnderlying {
+  user: number;
+  underlying: string;
+  underlying_price: string;
+  contract: string;
+  size: number;
+  entry_price: string;
+  mark_price: string;
+  mark_iv: string;
+  realised_pnl: string;
+  unrealised_pnl: string;
+  pending_orders: number;
+  close_order: {
+    id: number;
+    price: string;
+    is_liq: boolean;
+  } | null;
+  delta: string;
+  gamma: string;
+  vega: string;
+  theta: string;
+}
+⋮----
+export interface GetOptionsLiquidationResp {
+  time: number;
+  contract: string;
+  side: 'long' | 'short';
+  pnl: string;
+  text: string;
+  settle_size: string;
+}
+⋮----
+export interface SubmitOptionsOrderResp {
+  id: number;
+  user: number;
+  create_time: number;
+  finish_time: number;
+  finish_as:
+    | 'filled'
+    | 'cancelled'
+    | 'liquidated'
+    | 'ioc'
+    | 'auto_deleveraged'
+    | 'reduce_only'
+    | 'position_closed';
+  status: 'open' | 'finished';
+  contract: string;
+  size: number;
+  iceberg: number;
+  price: string;
+  is_close: boolean;
+  is_reduce_only: boolean;
+  is_liq: boolean;
+  tif: 'gtc' | 'ioc' | 'poc';
+  left: number;
+  fill_price: string;
+  text: string;
+  tkfr: string;
+  mkfr: string;
+  refu: number;
+  refr: string;
+}
+⋮----
+export interface OptionsUserHistoryRecord {
+  id: number;
+  create_time: number;
+  contract: string;
+  order_id: number;
+  size: number;
+  price: string;
+  underlying_price: string;
+  role: 'taker' | 'maker';
+}
+⋮----
+export interface OptionsMMPSettings {
+  underlying: string;
+  window: number;
+  frozen_period: number;
+  qty_limit: string;
+  delta_limit: string;
+  trigger_time_ms: number; // Trigger freeze time in milliseconds, 0 means no freeze triggered
+  frozen_until_ms: number; // Unfreeze time in milliseconds, if no frozen period is configured, no unfreeze time after freeze is triggered
+}
+⋮----
+trigger_time_ms: number; // Trigger freeze time in milliseconds, 0 means no freeze triggered
+frozen_until_ms: number; // Unfreeze time in milliseconds, if no frozen period is configured, no unfreeze time after freeze is triggered
+
+================
+File: src/types/response/rebate.ts
+================
+export interface AgencyTransactionHistoryRecord {
+  transaction_time: number;
+  user_id: number;
+  group_name: string;
+  fee: string;
+  fee_asset: string;
+  currency_pair: string;
+  amount: string;
+  amount_asset: string;
+  source: string;
+}
+⋮----
+export interface AgencyCommissionHistoryRecord {
+  commission_time: number;
+  user_id: number;
+  group_name: string;
+  commission_amount: string;
+  commission_asset: string;
+  source: string;
+}
+⋮----
+export interface PartnerSubordinate {
+  user_id: number;
+  user_join_time: number;
+  type: number;
+  desc: string;
+}
+⋮----
+export interface BrokerCommissionHistoryRecord {
+  commission_time: number;
+  user_id: number;
+  group_name: string;
+  amount: string;
+  fee: string;
+  fee_asset: string;
+  rebate_fee: string;
+  source: string;
+  currency_pair: string;
+  sub_broker_info: {
+    user_id: number;
+    original_commission_rate: string;
+    relative_commission_rate: string;
+    commission_rate: string;
+  };
+}
+⋮----
+export interface BrokerTransactionHistoryRecord {
+  transaction_time: number;
+  user_id: number;
+  group_name: string;
+  fee: string;
+  currency_pair: string;
+  amount: string;
+  fee_asset: string;
+  source: string;
+  sub_broker_info: {
+    user_id: number;
+    original_commission_rate: string;
+    relative_commission_rate: string;
+    commission_rate: string;
+  };
+}
+⋮----
+export interface PartnerCommission {
+  commission_time: number;
+  user_id: number;
+  group_name: string;
+  commission_amount: string;
+  commission_asset: string;
+  source: string;
+}
+⋮----
+export interface PartnerTransaction {
+  transaction_time: number;
+  user_id: number;
+  group_name: string;
+  fee: string;
+  fee_asset: string;
+  currency_pair: string;
+  amount: string;
+  amount_asset: string;
+  source: string;
+}
+
+================
 File: src/types/response/spot.ts
 ================
 /**==========================================================================================================================
@@ -5990,6 +5455,713 @@ export interface SpotHistoricTradeRecord {
   amend_text: string;
   sequence_id: string;
   text: string;
+}
+
+================
+File: src/types/response/subaccount.ts
+================
+export interface SubAccount {
+  remark?: string;
+  login_name: string;
+  password?: string;
+  email?: string;
+  state: number;
+  type: number;
+  user_id: number;
+  create_time: number;
+}
+⋮----
+export interface CreatedSubAccountAPIKey {
+  user_id: string;
+  mode?: number;
+  name?: string;
+  perms?: {
+    name?:
+      | 'wallet'
+      | 'spot'
+      | 'futures'
+      | 'delivery'
+      | 'earn'
+      | 'options'
+      | 'account'
+      | 'unified'
+      | 'loan';
+    read_only?: boolean;
+  }[];
+  ip_whitelist?: string[];
+  key: string;
+  state: number;
+  created_at: number;
+  updated_at: number;
+  last_access: number;
+}
+⋮----
+export interface SubAccountAPIKey {
+  user_id?: string;
+  mode?: number;
+  name?: string;
+  perms?: {
+    name?:
+      | 'wallet'
+      | 'spot'
+      | 'futures'
+      | 'delivery'
+      | 'earn'
+      | 'options'
+      | 'account'
+      | 'unified'
+      | 'loan';
+    read_only?: boolean;
+  }[];
+  ip_whitelist?: string[];
+  key?: string;
+  state?: number;
+  created_at?: number;
+  updated_at?: number;
+  last_access?: number;
+}
+⋮----
+export interface SubAccountMode {
+  user_id: number;
+  is_unified: boolean;
+  mode: 'classic' | 'multi_currency' | 'portfolio';
+}
+
+================
+File: src/types/response/unified.ts
+================
+export interface UnifiedAccountInfo {
+  user_id: number;
+  refresh_time: number;
+  locked: boolean;
+  balances: {
+    [key: string]: {
+      available: string;
+      freeze: string;
+      borrowed: string;
+      negative_liab: string;
+      futures_pos_liab: string;
+      equity: string;
+      total_freeze: string;
+      total_liab: string;
+      spot_in_use: string;
+      funding: string;
+      funding_version: string;
+      cross_balance: string;
+      iso_balance: string;
+      im: string;
+      mm: string;
+      mmr: string;
+      margin_balance: string;
+      available_margin: string;
+      imr?: string;
+      enabled_collateral?: boolean;
+    };
+  };
+  total: string;
+  borrowed: string;
+  total_initial_margin: string;
+  total_margin_balance: string;
+  total_maintenance_margin: string;
+  total_initial_margin_rate: string;
+  total_maintenance_margin_rate: string;
+  total_available_margin: string;
+  unified_account_total: string;
+  unified_account_total_liab: string;
+  unified_account_total_equity: string;
+  leverage: string;
+  spot_order_loss: string;
+  spot_hedge: boolean;
+  margin_mode?: string;
+  total_balance?: string;
+  cross_leverage?: string;
+  portfolio_margin?: string;
+  risk_level?: string;
+  is_all_collateral?: boolean;
+  borrow_amount?: string;
+  cross_margin_leverage?: string;
+  use_funding?: boolean;
+}
+⋮----
+export interface UnifiedLoan {
+  currency: string;
+  currency_pair: string;
+  amount: string;
+  type: 'platform' | 'margin';
+  create_time: number;
+  update_time: number;
+}
+⋮----
+export interface UnifiedLoanRecord {
+  id: number;
+  type: 'borrow' | 'repay';
+  repayment_type: 'none' | 'manual_repay' | 'auto_repay' | 'cancel_auto_repay';
+  currency_pair: string;
+  currency: string;
+  amount: string;
+  create_time: number;
+  borrow_type: string;
+}
+export interface UnifiedInterestRecord {
+  currency: string;
+  currency_pair: string;
+  actual_rate: string;
+  interest: string;
+  status: number;
+  type: 'platform' | 'margin';
+  create_time: number;
+}
+⋮----
+export interface UnifiedRiskUnitDetails {
+  user_id: number;
+  spot_hedge: boolean;
+  risk_units: {
+    symbol: string;
+    spot_in_use: string;
+    maintain_margin: string;
+    initial_margin: string;
+    delta: string;
+    gamma: string;
+    theta: string;
+    vega: string;
+  }[];
+}
+⋮----
+export interface UnifiedCurrencyDiscountTiers {
+  currency: string;
+  discount_tiers: {
+    tier: string;
+    discount: string;
+    lower_limit: string;
+    upper_limit: string;
+    leverage: string;
+  }[];
+}
+⋮----
+export interface UserCurrencyLeverageConfig {
+  current_leverage: string;
+  min_leverage: string;
+  max_leverage: string;
+  debit: string;
+  available_margin: string;
+  borrowable: string;
+  except_leverage_borrowable: string;
+}
+⋮----
+export interface UnifiedLoanCurrency {
+  name: string;
+  prec: string;
+  min_borrow_amount: string;
+  user_max_borrow_amount: string;
+  total_max_borrow_amount: string;
+  loan_status: string;
+}
+⋮----
+export interface UnifiedHistoryLendingRate {
+  currency: string;
+  tier: string;
+  tier_up_rate: string;
+  rates: {
+    time: number;
+    rate: string;
+  }[];
+}
+⋮----
+export interface MarginTier {
+  tier: string;
+  margin_rate: string;
+  lower_limit: string;
+  upper_limit: string;
+}
+⋮----
+export interface PortfolioMarginCalculation {
+  maintain_margin_total: string;
+  initial_margin_total: string;
+  calculate_time: number;
+  risk_unit: {
+    symbol: string;
+    spot_in_use: string;
+    maintain_margin: string;
+    initial_margin: string;
+    margin_result: {
+      type:
+        | 'original_position'
+        | 'long_delta_original_position'
+        | 'short_delta_original_position';
+      profit_loss_ranges: {
+        price_percentage: string;
+        implied_volatility_percentage: string;
+        profit_loss: string;
+      }[];
+      max_loss: {
+        price_percentage: string;
+        implied_volatility_percentage: string;
+        profit_loss: string;
+      };
+      mr1: string;
+      mr2: string;
+      mr3: string;
+      mr4: string;
+      delta: string;
+      gamma: string;
+      theta: string;
+      vega: string;
+    }[];
+  }[];
+}
+⋮----
+export interface UnifiedCollateralCurrenciesResp {
+  is_success: boolean;
+}
+
+================
+File: src/types/response/wallet.ts
+================
+export interface CurrencyChain {
+  chain: string;
+  name_cn: string;
+  name_en: string;
+  contract_address: string;
+  is_disabled: number;
+  is_deposit_disabled: number;
+  is_withdraw_disabled: number;
+  decimal: string;
+}
+⋮----
+export interface DepositRecord {
+  id: string;
+  txid: string;
+  timestamp: string;
+  amount: string;
+  currency: string;
+  address: string;
+  memo?: string;
+  status:
+    | 'BLOCKED' // Deposit Blocked
+    | 'DEP_CREDITED' // Deposit Credited, Withdrawal Pending Unlock
+    | 'DONE' // Funds Credited to Spot Account
+    | 'INVALID' // Invalid Transaction
+    | 'MANUAL' // Manual Review Required
+    | 'PEND' // Processing
+    | 'REVIEW' // Under Compliance Review
+    | 'TRACK'; // Tracking Block Confirmations, Pending Spot Account Credit
+  chain: string;
+}
+⋮----
+| 'BLOCKED' // Deposit Blocked
+| 'DEP_CREDITED' // Deposit Credited, Withdrawal Pending Unlock
+| 'DONE' // Funds Credited to Spot Account
+| 'INVALID' // Invalid Transaction
+| 'MANUAL' // Manual Review Required
+| 'PEND' // Processing
+| 'REVIEW' // Under Compliance Review
+| 'TRACK'; // Tracking Block Confirmations, Pending Spot Account Credit
+⋮----
+export interface CreateDepositAddressResp {
+  currency: string;
+  address: string;
+  multichain_addresses: {
+    chain: string;
+    address: string;
+    payment_id: string;
+    payment_name: string;
+    obtain_failed: number;
+  }[];
+}
+⋮----
+export interface SubAccountTransferRecord {
+  currency: string;
+  sub_account: string;
+  direction: 'to' | 'from';
+  amount: string;
+  uid: string;
+  client_order_id: string;
+  timest: string;
+  source: string;
+  sub_account_type: 'spot' | 'futures' | 'cross_margin' | 'delivery';
+}
+⋮----
+export interface WithdrawalStatus {
+  currency: string;
+  name: string;
+  name_cn: string;
+  deposit: string;
+  withdraw_percent: string;
+  withdraw_fix: string;
+  withdraw_day_limit: string;
+  withdraw_amount_mini: string;
+  withdraw_day_limit_remain: string;
+  withdraw_eachtime_limit: string;
+  withdraw_fix_on_chains: { [key: string]: string };
+  withdraw_percent_on_chains: { [key: string]: string };
+}
+⋮----
+export interface SubAccountMarginBalance {
+  currency_pair: string;
+  locked: boolean;
+  risk: string;
+  base: {
+    currency: string;
+    available: string;
+    locked: string;
+    borrowed: string;
+    interest: string;
+  };
+  quote: {
+    currency: string;
+    available: string;
+    locked: string;
+    borrowed: string;
+    interest: string;
+  };
+}
+⋮----
+export interface SubAccountFuturesBalancesResp {
+  uid: string;
+  available: {
+    [key: string]: {
+      total: string;
+      unrealised_pnl: string;
+      position_margin: string;
+      order_margin: string;
+      available: string;
+      point: string;
+      currency: string;
+      in_dual_mode: boolean;
+      enable_credit: boolean;
+      position_initial_margin: string;
+      maintenance_margin: string;
+      bonus: string;
+      enable_evolved_classic: boolean;
+      cross_order_margin: string;
+      cross_initial_margin: string;
+      cross_maintenance_margin: string;
+      cross_unrealised_pnl: string;
+      cross_available: string;
+      isolated_position_margin: string;
+      history: {
+        dnw: string;
+        pnl: string;
+        fee: string;
+        refr: string;
+        fund: string;
+        point_dnw: string;
+        point_fee: string;
+        point_refr: string;
+        bonus_dnw: string;
+        bonus_offset: string;
+      };
+    };
+  };
+}
+⋮----
+export interface SubAccountCrossMarginBalancesResp {
+  uid: string;
+  available: {
+    user_id: number;
+    locked: boolean;
+    balances: {
+      [key: string]: {
+        available: string;
+        freeze: string;
+        borrowed: string;
+        interest: string;
+      };
+    };
+    total: string;
+    borrowed: string;
+    borrowed_net: string;
+    net: string;
+    leverage: string;
+    interest: string;
+    risk: string;
+    total_initial_margin: string;
+    total_margin_balance: string;
+    total_maintenance_margin: string;
+    total_initial_margin_rate: string;
+    total_maintenance_margin_rate: string;
+    total_available_margin: string;
+  };
+}
+⋮----
+export interface SavedAddress {
+  currency: string;
+  chain: string;
+  address: string;
+  name: string;
+  tag: string;
+  verified: string;
+}
+⋮----
+export interface TradingFees {
+  user_id: number;
+  taker_fee: string;
+  maker_fee: string;
+  gt_discount: boolean;
+  gt_taker_fee: string;
+  gt_maker_fee: string;
+  loan_fee: string;
+  point_type: string;
+  futures_taker_fee: string;
+  futures_maker_fee: string;
+  delivery_taker_fee: string;
+  delivery_maker_fee: string;
+  debit_fee: number;
+}
+⋮----
+export interface GetBalancesResp {
+  total: {
+    amount: string;
+    currency: string;
+    unrealised_pnl?: string;
+    borrowed?: string;
+  };
+  details: {
+    [key: string]: {
+      amount: string;
+      currency: string;
+      unrealised_pnl?: string;
+      borrowed?: string;
+    };
+  };
+}
+⋮----
+export interface SmallBalanceRecord {
+  currency: string;
+  available_balance: string;
+  estimated_as_btc: string;
+  convertible_to_gt: string;
+}
+⋮----
+export interface SmallBalanceHistoryRecord {
+  id: string;
+  currency: string;
+  amount: string;
+  gt_amount: string;
+  create_time: number;
+}
+⋮----
+export interface PushOrder {
+  id: number;
+  push_uid: number;
+  receive_uid: number;
+  currency: string;
+  amount: string;
+  create_time: number;
+  status:
+    | 'CREATING'
+    | 'PENDING'
+    | 'CANCELLING'
+    | 'CANCELLED'
+    | 'REFUSING'
+    | 'REFUSED'
+    | 'RECEIVING'
+    | 'RECEIVED';
+  message: string;
+}
+
+================
+File: src/types/response/withdrawal.ts
+================
+export interface WithdrawalRecord {
+  id: string;
+  txid: string;
+  block_number: string;
+  withdraw_order_id: string;
+  timestamp: string;
+  amount: string;
+  currency: string;
+  address: string;
+  memo?: string;
+  status:
+    | 'BCODE' // Deposit Code Operation
+    | 'CANCEL' // Cancelled
+    | 'CANCELPEND' // Withdrawal Cancellation Pending
+    | 'DMOVE' // Pending Manual Review
+    | 'DONE' // Completed (Only considered truly on-chain when block_number > 0)
+    | 'EXTPEND' // Sent and Waiting for Confirmation
+    | 'FAIL' // On-Chain Failure Pending Confirmation
+    | 'FVERIFY' // Facial Verification in Progress
+    | 'INVALID' // Invalid Transaction
+    | 'LOCKED' // Wallet-Side Order Locked
+    | 'MANUAL' // Pending Manual Review
+    | 'PEND' // Processing
+    | 'PROCES' // Processing
+    | 'REJECT' // Rejected
+    | 'REQUEST' // Request in Progress
+    | 'REVIEW' // Under Review
+    | 'SPLITPEND' // Split Pending
+    | 'VERIFY'; // Verification in Progress
+  chain: string;
+}
+⋮----
+| 'BCODE' // Deposit Code Operation
+| 'CANCEL' // Cancelled
+| 'CANCELPEND' // Withdrawal Cancellation Pending
+| 'DMOVE' // Pending Manual Review
+| 'DONE' // Completed (Only considered truly on-chain when block_number > 0)
+| 'EXTPEND' // Sent and Waiting for Confirmation
+| 'FAIL' // On-Chain Failure Pending Confirmation
+| 'FVERIFY' // Facial Verification in Progress
+| 'INVALID' // Invalid Transaction
+| 'LOCKED' // Wallet-Side Order Locked
+| 'MANUAL' // Pending Manual Review
+| 'PEND' // Processing
+| 'PROCES' // Processing
+| 'REJECT' // Rejected
+| 'REQUEST' // Request in Progress
+| 'REVIEW' // Under Review
+| 'SPLITPEND' // Split Pending
+| 'VERIFY'; // Verification in Progress
+
+================
+File: src/types/websockets/client.ts
+================
+/**
+ * Event args for subscribing/unsubscribing
+ */
+⋮----
+// export type WsTopicSubscribePrivateArgsV2 =
+//   | WsTopicSubscribePrivateInstIdArgsV2
+//   | WsTopicSubscribePrivateCoinArgsV2;
+⋮----
+// export type WsTopicSubscribeEventArgsV2 =
+//   | WsTopicSubscribePublicArgsV2
+//   | WsTopicSubscribePrivateArgsV2;
+⋮----
+/** General configuration for the WebsocketClient */
+export interface WSClientConfigurableOptions {
+  /** Your API key */
+  apiKey?: string;
+
+  /** Your API secret */
+  apiSecret?: string;
+
+  useTestnet?: boolean;
+
+  /** Define a recv window when preparing a private websocket signature. This is in milliseconds, so 5000 == 5 seconds */
+  recvWindow?: number;
+
+  /** How often to check if the connection is alive */
+  pingInterval?: number;
+
+  /** How long to wait for a pong (heartbeat reply) before assuming the connection is dead */
+  pongTimeout?: number;
+
+  /** Delay in milliseconds before respawning the connection */
+  reconnectTimeout?: number;
+
+  requestOptions?: {};
+
+  wsUrl?: string;
+
+  /**
+   * Allows you to provide a custom "signMessage" function, e.g. to use node's much faster createHmac method
+   *
+   * Look in the examples folder for a demonstration on using node's createHmac instead.
+   */
+  customSignMessageFn?: (message: string, secret: string) => Promise<string>;
+
+  /**
+   * If you authenticated the WS API before, automatically try to re-authenticate the WS API if you're disconnected/reconnected for any reason.
+   */
+  reauthWSAPIOnReconnect?: boolean;
+}
+⋮----
+/** Your API key */
+⋮----
+/** Your API secret */
+⋮----
+/** Define a recv window when preparing a private websocket signature. This is in milliseconds, so 5000 == 5 seconds */
+⋮----
+/** How often to check if the connection is alive */
+⋮----
+/** How long to wait for a pong (heartbeat reply) before assuming the connection is dead */
+⋮----
+/** Delay in milliseconds before respawning the connection */
+⋮----
+/**
+   * Allows you to provide a custom "signMessage" function, e.g. to use node's much faster createHmac method
+   *
+   * Look in the examples folder for a demonstration on using node's createHmac instead.
+   */
+⋮----
+/**
+   * If you authenticated the WS API before, automatically try to re-authenticate the WS API if you're disconnected/reconnected for any reason.
+   */
+⋮----
+/**
+ * WS configuration that's always defined, regardless of user configuration
+ * (usually comes from defaults if there's no user-provided values)
+ */
+export interface WebsocketClientOptions extends WSClientConfigurableOptions {
+  pingInterval: number;
+  pongTimeout: number;
+  reconnectTimeout: number;
+  recvWindow: number;
+  authPrivateConnectionsOnConnect: boolean;
+  authPrivateRequests: boolean;
+  reauthWSAPIOnReconnect: boolean;
+}
+
+================
+File: src/types/websockets/events.ts
+================
+export interface WsDataEvent<TData = any, TWSKey = string> {
+  data: TData;
+  table: string;
+  wsKey: TWSKey;
+}
+
+================
+File: src/types/websockets/requests.ts
+================
+import { CHANNEL_ID } from '../../lib/requestUtils.js';
+import { WSAPITopic } from './wsAPI.js';
+⋮----
+export type WsOperation = 'subscribe' | 'unsubscribe' | 'auth';
+⋮----
+export interface WsRequestAuthGate {
+  method: 'api_key';
+  KEY: string;
+  SIGN: string;
+}
+⋮----
+export interface WsRequestPing {
+  time: number;
+  channel: 'spot.ping' | 'futures.ping' | 'options.ping' | 'announcement.ping';
+}
+⋮----
+export interface WsRequestOperationGate<
+  TWSTopic extends string,
+  TWSPayload = any,
+> {
+  time: number;
+  id?: number;
+  channel: TWSTopic;
+  auth?: WsRequestAuthGate;
+  event?: WsOperation;
+  payload?: TWSPayload;
+}
+⋮----
+export interface WSAPIRequest<
+  TRequestParams = any,
+  TWSChannel extends WSAPITopic = any,
+> {
+  time: number;
+  id?: number;
+  channel: TWSChannel;
+  event: 'api';
+  payload: {
+    req_id: string;
+    req_param?: TRequestParams | string;
+    req_header: {
+      'X-Gate-Channel-Id': typeof CHANNEL_ID;
+    };
+    api_key?: string;
+    signature?: string;
+    timestamp?: string;
+  };
 }
 
 ================
@@ -6383,1247 +6555,54 @@ export interface WsAPITopicResponseMap {
 // }
 
 ================
-File: examples/ws-api-client.ts
+File: src/types/shared.ts
 ================
-import { WebsocketAPIClient, WS_KEY_MAP } from '../src/index.js';
-// import { LogParams, WebsocketClient } from 'gateio-api'; // normally you should install this module via npm: `npm install gateio-api`
+export type GateBaseUrlKey =
+  | 'live'
+  | 'futuresLiveAlternative'
+  | 'futuresTestnet';
 ⋮----
-async function start()
+// interfaces
 ⋮----
-/**
-     * Optional: authenticate in advance. This will prepare and authenticate a connection.
-     * Useful to save time for the first request but completely optional. It will also happen automatically when you make your first request.
-     */
-// console.log(new Date(), 'Authenticating in advance...');
-// await client.getWSClient().connectWSAPI('spotV4');
-// console.log(new Date(), 'Authenticating in advance...OK!');
-⋮----
-/* ============ SPOT TRADING EXAMPLES ============ */
-⋮----
-// SPOT ORDER PLACE - Submit a new spot order
-⋮----
-// SPOT ORDER CANCEL - Cancel a specific spot order
-⋮----
-// SPOT ORDER CANCEL BY IDS - Cancel orders by ID list
-⋮----
-// SPOT ORDER CANCEL BY CURRENCY PAIR - Cancel all orders for a currency pair
-⋮----
-// SPOT ORDER AMEND - Update an existing spot order
-⋮----
-// SPOT ORDER STATUS - Get status of a specific spot order
-⋮----
-// SPOT ORDER LIST - Get list of spot orders
-⋮----
-/* ============ FUTURES TRADING EXAMPLES ============ */
-⋮----
-/**
-     * Gate has different websocket groups depending on the futures product.
-     *
-     * This affects which connection your command is sent to, so make sure to pass one matching your request. Look at WS_KEY_MAP (or the examples below) for details on the available product groups.
-     */
-⋮----
-/**
-     * Also optional, as for spot. Keep in mind the first parameter (wsKey) might vary depending on which WS URL is needed.
-     */
-⋮----
-// console.log(new Date(), 'Authenticating in advance...');
-// await client.getWSClient().connectWSAPI(futuresConnectionGroup);
-// await client.getWSClient().connectWSAPI('perpFuturesUSDTV4');
-// await client.getWSClient().connectWSAPI('perpFuturesBTCV4');
-// await client.getWSClient().connectWSAPI('deliveryFuturesUSDTV4');
-// await client.getWSClient().connectWSAPI('perpFuturesBTCV4');
-// console.log(new Date(), 'Authenticating in advance...OK!');
-⋮----
-// FUTURES ORDER PLACE - Submit a new futures order
-⋮----
-// FUTURES ORDER BATCH PLACE - Submit multiple futures orders
-⋮----
-// FUTURES ORDER CANCEL - Cancel a specific futures order
-⋮----
-// FUTURES ORDER CANCEL BY IDS - Cancel futures orders by ID list
-⋮----
-// FUTURES ORDER CANCEL ALL - Cancel all open futures orders
-⋮----
-// FUTURES ORDER AMEND - Update an existing futures order
-⋮----
-// FUTURES ORDER LIST - Get list of futures orders
-⋮----
-// FUTURES ORDER STATUS - Get status of a specific futures order
-
-================
-File: src/WebsocketAPIClient.ts
-================
-import { DefaultLogger } from './lib/logger.js';
-import { WS_KEY_MAP } from './lib/websocket/websocket-util.js';
-import { WSClientConfigurableOptions } from './types/websockets/client.js';
-import {
-  WSAPIFuturesOrder,
-  WSAPIFuturesOrderAmendReq,
-  WSAPIFuturesOrderBatchPlaceRespItem,
-  WSAPIFuturesOrderCancelCPReq,
-  WSAPIFuturesOrderCancelIdsRespItem,
-  WSAPIFuturesOrderCancelReq,
-  WSAPIFuturesOrderListReq,
-  WSAPIFuturesOrderPlaceReq,
-  WSAPIFuturesOrderStatusReq,
-  WSAPIResponse,
-  WSAPISpotOrder,
-  WSAPISpotOrderAmendReq,
-  WSAPISpotOrderCancelCPReq,
-  WSAPISpotOrderCancelIdsReq,
-  WSAPISpotOrderCancelIdsRespItem,
-  WSAPISpotOrderCancelReq,
-  WSAPISpotOrderListReq,
-  WSAPISpotOrderPlaceReq,
-  WSAPISpotOrderStatusReq,
-  WSAPIWsKey,
-} from './types/websockets/wsAPI.js';
-import { WebsocketClient } from './WebsocketClient.js';
-⋮----
-/**
- * Configurable options specific to only the REST-like WebsocketAPIClient
- */
-export interface WSAPIClientConfigurableOptions {
-  /**
-   * Default: true
-   *
-   * Attach default event listeners, which will console log any high level
-   * events (opened/reconnecting/reconnected/etc).
-   *
-   * If you disable this, you should set your own event listeners
-   * on the embedded WS Client `wsApiClient.getWSClient().on(....)`.
-   */
-  attachEventListeners: boolean;
+export interface FromToPageLimit {
+  from: number;
+  to: number;
+  page: number;
+  limit: number;
 }
 ⋮----
-/**
-   * Default: true
-   *
-   * Attach default event listeners, which will console log any high level
-   * events (opened/reconnecting/reconnected/etc).
-   *
-   * If you disable this, you should set your own event listeners
-   * on the embedded WS Client `wsApiClient.getWSClient().on(....)`.
-   */
-⋮----
-/**
- * This is a minimal Websocket API wrapper around the WebsocketClient.
- *
- * Some methods support passing in a custom "wsKey". This is a reference to which WS connection should
- * be used to transmit that message. This is only useful if you wish to use an alternative wss
- * domain that is supported by the SDK.
- *
- * Note: To use testnet, don't set the wsKey - use `testnet: true` in
- * the constructor instead.
- *
- * Note: You can also directly use the sendWSAPIRequest() method to make WS API calls, but some
- * may find the below methods slightly more intuitive.
- *
- * Refer to the WS API promises example for a more detailed example on using sendWSAPIRequest() directly:
- * https://github.com/tiagosiebler/gateio-api/blob/master/examples/ws-private-spot-wsapi.ts#L119
- */
-export class WebsocketAPIClient
-⋮----
-constructor(
-    options?: WSClientConfigurableOptions &
-      Partial<WSAPIClientConfigurableOptions>,
-    logger?: DefaultLogger,
-)
-⋮----
-public getWSClient(): WebsocketClient
-⋮----
-public setTimeOffsetMs(newOffset: number): void
-⋮----
-/*
-   *
-   * SPOT - Trading requests
-   *
-   */
-⋮----
-/**
-   * Submit a spot order
-   */
-submitNewSpotOrder(
-    params: WSAPISpotOrderPlaceReq,
-    wsKey?: WSAPIWsKey,
-): Promise<WSAPIResponse<WSAPISpotOrder>>
-⋮----
-/**
-   * Cancel a spot order
-   */
-cancelSpotOrder(
-    params: WSAPISpotOrderCancelReq,
-    wsKey?: WSAPIWsKey,
-): Promise<WSAPIResponse<WSAPISpotOrder>>
-⋮----
-/**
-   * Cancel all spot orders with the given id list
-   */
-cancelSpotOrderById(
-    params: WSAPISpotOrderCancelIdsReq[],
-    wsKey?: WSAPIWsKey,
-): Promise<WSAPIResponse<WSAPISpotOrderCancelIdsRespItem[]>>
-⋮----
-/**
-   * Cancel a spot order for a given symbol
-   */
-cancelSpotOrderForSymbol(
-    params: WSAPISpotOrderCancelCPReq,
-    wsKey?: WSAPIWsKey,
-): Promise<WSAPIResponse<WSAPISpotOrder[]>>
-⋮----
-/**
-   * Update a spot order
-   */
-updateSpotOrder(
-    params: WSAPISpotOrderAmendReq,
-    wsKey?: WSAPIWsKey,
-): Promise<WSAPIResponse<WSAPISpotOrder>>
-⋮----
-/**
-   * Get the status of a spot order
-   */
-getSpotOrderStatus(
-    params: WSAPISpotOrderStatusReq,
-    wsKey?: WSAPIWsKey,
-): Promise<WSAPIResponse<WSAPISpotOrder>>
-⋮----
-/**
-   * Get all spot orders
-   */
-getSpotOrders(
-    params: WSAPISpotOrderListReq,
-    wsKey?: WSAPIWsKey,
-): Promise<WSAPIResponse<WSAPISpotOrder[]>>
-⋮----
-/*
-   *
-   * Futures - Trading requests
-   *
-   */
-⋮----
-/**
-   * Submit a futures order.
-   *
-   * Note: without a wsKey, this defaults to the perpFuturesUSDTV4 connection
-   */
-submitNewFuturesOrder(
-    params: WSAPIFuturesOrderPlaceReq,
-    wsKey?: WSAPIWsKey,
-): Promise<WSAPIResponse<WSAPIFuturesOrder>>
-⋮----
-/**
-   * Submit a batch of futures orders
-   *
-   * Note: without a wsKey, this defaults to the perpFuturesUSDTV4 connection
-   */
-submitNewFuturesBatchOrder(
-    params: WSAPIFuturesOrderPlaceReq[],
-    wsKey?: WSAPIWsKey,
-): Promise<WSAPIResponse<WSAPIFuturesOrderBatchPlaceRespItem[]>>
-⋮----
-/**
-   * Cancel a futures order
-   *
-   * Note: without a wsKey, this defaults to the perpFuturesUSDTV4 connection
-   */
-cancelFuturesOrder(
-    params: WSAPIFuturesOrderCancelReq,
-    wsKey?: WSAPIWsKey,
-): Promise<WSAPIResponse<WSAPIFuturesOrder>>
-⋮----
-/**
-   * Cancel futures orders by id list
-   *
-   * Note: without a wsKey, this defaults to the perpFuturesUSDTV4 connection
-   */
-cancelFuturesOrderById(
-    params: string[],
-    wsKey?: WSAPIWsKey,
-): Promise<WSAPIResponse<WSAPIFuturesOrderCancelIdsRespItem[]>>
-⋮----
-/**
-   * Cancel all open futures orders
-   *
-   * Note: without a wsKey, this defaults to the perpFuturesUSDTV4 connection
-   */
-cancelFuturesAllOpenOrders(
-    params: WSAPIFuturesOrderCancelCPReq,
-    wsKey?: WSAPIWsKey,
-): Promise<WSAPIResponse<WSAPIFuturesOrder[]>>
-⋮----
-/**
-   * Update a futures order
-   *
-   * Note: without a wsKey, this defaults to the perpFuturesUSDTV4 connection
-   */
-updateFuturesOrder(
-    params: WSAPIFuturesOrderAmendReq,
-    wsKey?: WSAPIWsKey,
-): Promise<WSAPIResponse<WSAPIFuturesOrder>>
-⋮----
-/**
-   * Get all futures orders
-   *
-   * Note: without a wsKey, this defaults to the perpFuturesUSDTV4 connection
-   */
-getFuturesOrders(
-    params: WSAPIFuturesOrderListReq,
-    wsKey?: WSAPIWsKey,
-): Promise<WSAPIResponse<WSAPIFuturesOrder[]>>
-⋮----
-/**
-   * Get futures order status
-   *
-   * Note: without a wsKey, this defaults to the perpFuturesUSDTV4 connection
-   */
-getFuturesOrderStatus(
-    params: WSAPIFuturesOrderStatusReq,
-    wsKey?: WSAPIWsKey,
-): Promise<WSAPIResponse<WSAPIFuturesOrder>>
-⋮----
-/**
-   *
-   *
-   *
-   *
-   *
-   *
-   *
-   * Private methods for handling some of the convenience/automation provided by the WS API Client
-   *
-   *
-   *
-   *
-   *
-   *
-   *
-   */
-⋮----
-private setupDefaultEventListeners()
-⋮----
-/**
-       * General event handlers for monitoring the WebsocketClient
-       */
-
-================
-File: src/lib/BaseWSClient.ts
-================
-import EventEmitter from 'events';
-import WebSocket from 'isomorphic-ws';
-⋮----
-import {
-  WebsocketClientOptions,
-  WSClientConfigurableOptions,
-} from '../types/websockets/client.js';
-import { WsOperation } from '../types/websockets/requests.js';
-import { WS_LOGGER_CATEGORY } from '../WebsocketClient.js';
-import { DefaultLogger } from './logger.js';
-import { isMessageEvent, MessageEventLike } from './requestUtils.js';
-import { checkWebCryptoAPISupported } from './webCryptoAPI.js';
-import {
-  safeTerminateWs,
-  WsTopicRequest,
-  WsTopicRequestOrStringTopic,
-} from './websocket/websocket-util.js';
-import { WsStore } from './websocket/WsStore.js';
-import {
-  WSConnectedResult,
-  WsConnectionStateEnum,
-} from './websocket/WsStore.types.js';
-⋮----
-interface WSClientEventMap<WsKey extends string> {
-  /** Connection opened. If this connection was previously opened and reconnected, expect the reconnected event instead */
-  open: (evt: {
-    wsKey: WsKey;
-    event: any;
-    wsUrl: string;
-    ws: WebSocket;
-  }) => void /** Reconnecting a dropped connection */;
-  reconnect: (evt: { wsKey: WsKey; event: any }) => void;
-  /** Successfully reconnected a connection that dropped */
-  reconnected: (evt: {
-    wsKey: WsKey;
-    event: any;
-    wsUrl: string;
-    ws: WebSocket;
-  }) => void;
-  /** Connection closed */
-  close: (evt: { wsKey: WsKey; event: any }) => void;
-  /** Received reply to websocket command (e.g. after subscribing to topics) */
-  response: (response: any & { wsKey: WsKey }) => void;
-  /** Received data for topic */
-  update: (response: any & { wsKey: WsKey }) => void;
-  /** Exception from ws client OR custom listeners (e.g. if you throw inside your event handler) */
-  exception: (response: any & { wsKey: WsKey }) => void;
-  error: (response: any & { wsKey: WsKey }) => void;
-  /** Confirmation that a connection successfully authenticated */
-  authenticated: (event: { wsKey: WsKey; event: any }) => void;
-}
-⋮----
-/** Connection opened. If this connection was previously opened and reconnected, expect the reconnected event instead */
-⋮----
-}) => void /** Reconnecting a dropped connection */;
-⋮----
-/** Successfully reconnected a connection that dropped */
-⋮----
-/** Connection closed */
-⋮----
-/** Received reply to websocket command (e.g. after subscribing to topics) */
-⋮----
-/** Received data for topic */
-⋮----
-/** Exception from ws client OR custom listeners (e.g. if you throw inside your event handler) */
-⋮----
-/** Confirmation that a connection successfully authenticated */
-⋮----
-export interface EmittableEvent<TEvent = any> {
-  eventType: 'response' | 'update' | 'exception' | 'authenticated';
-  event: TEvent;
-}
-⋮----
-// Type safety for on and emit handlers: https://stackoverflow.com/a/61609010/880837
-export interface BaseWebsocketClient<TWSKey extends string> {
-  on<U extends keyof WSClientEventMap<TWSKey>>(
-    event: U,
-    listener: WSClientEventMap<TWSKey>[U],
-  ): this;
-
-  emit<U extends keyof WSClientEventMap<TWSKey>>(
-    event: U,
-    ...args: Parameters<WSClientEventMap<TWSKey>[U]>
-  ): boolean;
-}
-⋮----
-on<U extends keyof WSClientEventMap<TWSKey>>(
-    event: U,
-    listener: WSClientEventMap<TWSKey>[U],
-  ): this;
-⋮----
-emit<U extends keyof WSClientEventMap<TWSKey>>(
-    event: U,
-    ...args: Parameters<WSClientEventMap<TWSKey>[U]>
-  ): boolean;
-⋮----
-/**
- * Users can conveniently pass topics as strings or objects (object has topic name + optional params).
- *
- * This method normalises topics into objects (object has topic name + optional params).
- */
-function getNormalisedTopicRequests(
-  wsTopicRequests: WsTopicRequestOrStringTopic<string>[],
-): WsTopicRequest<string>[]
-⋮----
-// passed as string, convert to object
-⋮----
-// already a normalised object, thanks to user
-⋮----
-/**
- * Base WebSocket abstraction layer. Handles connections, tracking each connection as a unique "WS Key"
- */
-// eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
-export abstract class BaseWebsocketClient<
-⋮----
-/**
-   * The WS connections supported by the client, each identified by a unique primary key
-   */
-⋮----
-/**
-   * State store to track a list of topics (topic requests) we are expected to be subscribed to if reconnected
-   */
-⋮----
-constructor(
-    options?: WSClientConfigurableOptions,
-    logger?: typeof DefaultLogger,
-)
-⋮----
-// Some defaults:
-⋮----
-// Gate.io only has one connection (for both public & private). Auth works with every sub, not on connect, so this is turned off.
-⋮----
-// Gate.io requires auth to be added to every request, when subscribing to private topics. This is handled automatically.
-⋮----
-// Automatically re-auth WS API, if we were auth'd before and get reconnected
-⋮----
-// Check Web Crypto API support when credentials are provided and no custom sign function is used
-⋮----
-protected abstract isAuthOnConnectWsKey(wsKey: TWSKey): boolean;
-⋮----
-protected abstract sendPingEvent(wsKey: TWSKey, ws: WebSocket): void;
-⋮----
-protected abstract sendPongEvent(wsKey: TWSKey, ws: WebSocket): void;
-⋮----
-protected abstract isWsPing(data: any): boolean;
-⋮----
-protected abstract isWsPong(data: any): boolean;
-⋮----
-protected abstract getWsAuthRequestEvent(wsKey: TWSKey): Promise<object>;
-⋮----
-protected abstract isPrivateTopicRequest(
-    request: WsTopicRequest<string>,
-    wsKey: TWSKey,
-  ): boolean;
-⋮----
-protected abstract getPrivateWSKeys(): TWSKey[];
-⋮----
-protected abstract getWsUrl(wsKey: TWSKey): string;
-⋮----
-protected abstract getMaxTopicsPerSubscribeEvent(
-    wsKey: TWSKey,
-  ): number | null;
-⋮----
-/**
-   * Returns a list of string events that can be individually sent upstream to complete subscribing/unsubscribing/etc to these topics
-   */
-protected abstract getWsOperationEventsForTopics(
-    topics: WsTopicRequest<string>[],
-    wsKey: TWSKey,
-    operation: WsOperation,
-  ): Promise<string[]>;
-⋮----
-/**
-   * Abstraction called to sort ws events into emittable event types (response to a request, data update, etc)
-   */
-protected abstract resolveEmittableEvents(
-    wsKey: TWSKey,
-    event: MessageEventLike,
-  ): EmittableEvent[];
-⋮----
-/**
-   * Request connection of all dependent (public & private) websockets, instead of waiting for automatic connection by library
-   */
-protected abstract connectAll(): Promise<WSConnectedResult | undefined>[];
-⋮----
-protected isPrivateWsKey(wsKey: TWSKey): boolean
-⋮----
-/** Returns auto-incrementing request ID, used to track promise references for async requests */
-protected getNewRequestId(): string
-⋮----
-protected abstract sendWSAPIRequest(
-    wsKey: TWSKey,
-    channel: string,
-    params?: any,
-  ): Promise<unknown>;
-⋮----
-protected abstract sendWSAPIRequest(
-    wsKey: TWSKey,
-    channel: string,
-    params: any,
-  ): Promise<unknown>;
-⋮----
-public getTimeOffsetMs()
-⋮----
-// TODO: not implemented
-public setTimeOffsetMs(newOffset: number)
-⋮----
-/**
-   * Don't call directly! Use subscribe() instead!
-   *
-   * Subscribe to one or more topics on a WS connection (identified by WS Key).
-   *
-   * - Topics are automatically cached
-   * - Connections are automatically opened, if not yet connected
-   * - Authentication is automatically handled
-   * - Topics are automatically resubscribed to, if something happens to the connection, unless you call unsubsribeTopicsForWsKey(topics, key).
-   *
-   * @param wsRequests array of topics to subscribe to
-   * @param wsKey ws key referring to the ws connection these topics should be subscribed on
-   */
-protected subscribeTopicsForWsKey(
-    wsTopicRequests: WsTopicRequestOrStringTopic<string>[],
-    wsKey: TWSKey,
-)
-⋮----
-// Store topics, so future automation (post-auth, post-reconnect) has everything needed to resubscribe automatically
-⋮----
-// start connection process if it hasn't yet begun. Topics are automatically subscribed to on-connect
-⋮----
-// Subscribe should happen automatically once connected, nothing to do here after topics are added to wsStore.
-⋮----
-/**
-       * Are we in the process of connection? Nothing to send yet.
-       */
-⋮----
-// We're connected. Check if auth is needed and if already authenticated
-⋮----
-/**
-       * If not authenticated yet and auth is required, don't request topics yet.
-       *
-       * Auth should already automatically be in progress, so no action needed from here. Topics will automatically subscribe post-auth success.
-       */
-⋮----
-// Finally, request subscription to topics if the connection is healthy and ready
-⋮----
-protected unsubscribeTopicsForWsKey(
-    wsTopicRequests: WsTopicRequestOrStringTopic<string>[],
-    wsKey: TWSKey,
-)
-⋮----
-// Store topics, so future automation (post-auth, post-reconnect) has everything needed to resubscribe automatically
-⋮----
-// If not connected, don't need to do anything.
-// Removing the topic from the store is enough to stop it from being resubscribed to on reconnect.
-⋮----
-// We're connected. Check if auth is needed and if already authenticated
-⋮----
-/**
-       * If not authenticated yet and auth is required, don't need to do anything.
-       * We don't subscribe to topics until auth is complete anyway.
-       */
-⋮----
-// Finally, request subscription to topics if the connection is healthy and ready
-⋮----
-/**
-   * Splits topic requests into two groups, public & private topic requests
-   */
-private sortTopicRequestsIntoPublicPrivate(
-    wsTopicRequests: WsTopicRequest<string>[],
-    wsKey: TWSKey,
-):
-⋮----
-/** Get the WsStore that tracks websockets & topics */
-public getWsStore(): WsStore<TWSKey, WsTopicRequest<string>>
-⋮----
-public close(wsKey: TWSKey, force?: boolean)
-⋮----
-public closeAll(force?: boolean)
-⋮----
-public isConnected(wsKey: TWSKey): boolean
-⋮----
-/**
-   * Request connection to a specific websocket, instead of waiting for automatic connection.
-   */
-protected async connect(
-    wsKey: TWSKey,
-): Promise<WSConnectedResult | undefined>
-⋮----
-private connectToWsUrl(url: string, wsKey: TWSKey): WebSocket
-⋮----
-private parseWsError(context: string, error: any, wsKey: TWSKey)
-⋮----
-/** Get a signature, build the auth request and send it */
-private async sendAuthRequest(wsKey: TWSKey): Promise<unknown>
-⋮----
-// console.log('ws auth req', request);
-⋮----
-private reconnectWithDelay(wsKey: TWSKey, connectionDelayMs: number)
-⋮----
-private ping(wsKey: TWSKey)
-⋮----
-private clearTimers(wsKey: TWSKey)
-⋮----
-// Send a ping at intervals
-private clearPingTimer(wsKey: TWSKey)
-⋮----
-// Expect a pong within a time limit
-private clearPongTimer(wsKey: TWSKey)
-⋮----
-// this.logger.trace(`Cleared pong timeout for "${wsKey}"`);
-⋮----
-// this.logger.trace(`No active pong timer for "${wsKey}"`);
-⋮----
-/**
-   * Simply builds and sends subscribe events for a list of topics for a ws key
-   *
-   * @private Use the `subscribe(topics)` or `subscribeTopicsForWsKey(topics, wsKey)` method to subscribe to topics. Send WS message to subscribe to topics.
-   */
-private async requestSubscribeTopics(
-    wsKey: TWSKey,
-    topics: WsTopicRequest<string>[],
-)
-⋮----
-// Automatically splits requests into smaller batches, if needed
-⋮----
-`Subscribing to ${topics.length} "${wsKey}" topics in ${subscribeWsMessages.length} batches.`, // Events: "${JSON.stringify(topics)}"
-⋮----
-// console.log(`batches: `, JSON.stringify(subscribeWsMessages, null, 2));
-⋮----
-// this.logger.trace(`Sending batch via message: "${wsMessage}"`);
-⋮----
-/**
-   * Simply builds and sends unsubscribe events for a list of topics for a ws key
-   *
-   * @private Use the `unsubscribe(topics)` method to unsubscribe from topics. Send WS message to unsubscribe from topics.
-   */
-private async requestUnsubscribeTopics(
-    wsKey: TWSKey,
-    wsTopicRequests: WsTopicRequest<string>[],
-)
-⋮----
-/**
-   * Try sending a string event on a WS connection (identified by the WS Key)
-   */
-public tryWsSend(
-    wsKey: TWSKey,
-    wsMessage: string,
-    throwExceptions?: boolean,
-)
-⋮----
-private async onWsOpen(
-    event: any,
-    wsKey: TWSKey,
-    url: string,
-    ws: WebSocket,
-)
-⋮----
-// Resolve & cleanup deferred "connection attempt in progress" promise
-⋮----
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-⋮----
-// Remove before resolving, in case there's more requests queued
-⋮----
-// Some websockets require an auth packet to be sent after opening the connection
-⋮----
-// Reconnect to topics known before it connected
-⋮----
-// Request sub to public topics, if any
-⋮----
-// Request sub to private topics, if auth on connect isn't needed
-⋮----
-// If enabled, automatically reauth WS API if reconnected
-⋮----
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-⋮----
-/**
-   * Handle subscription to private topics _after_ authentication successfully completes asynchronously.
-   *
-   * Only used for exchanges that require auth before sending private topic subscription requests
-   */
-private onWsAuthenticated(
-    wsKey: TWSKey,
-    event: { isWSAPI?: boolean; WSAPIAuthChannel?: string },
-)
-⋮----
-// Resolve & cleanup deferred "auth attempt in progress" promise
-⋮----
-// Remove before continuing, in case there's more requests queued
-⋮----
-private onWsMessage(event: unknown, wsKey: TWSKey, ws: WebSocket)
-⋮----
-// any message can clear the pong timer - wouldn't get a message if the ws wasn't working
-⋮----
-// console.log(`raw event: `, { data, dataType, emittableEvents });
-⋮----
-private onWsClose(event: unknown, wsKey: TWSKey)
-⋮----
-// unintentional close, attempt recovery
-⋮----
-// clean up any pending promises for this connection
-⋮----
-// intentional close - clean up
-// clean up any pending promises for this connection
-⋮----
-// clean up any pending promises for this connection
-⋮----
-// This was an intentional close, delete all state for this connection, as if it never existed:
-⋮----
-private getWs(wsKey: TWSKey)
-⋮----
-private setWsState(wsKey: TWSKey, state: WsConnectionStateEnum)
-⋮----
-/**
-   * Promise-driven method to assert that a ws has successfully connected (will await until connection is open)
-   */
-protected async assertIsConnected(wsKey: TWSKey): Promise<unknown>
-⋮----
-// Already in progress? Await shared promise and retry
-⋮----
-// Start connection, it should automatically store/return a promise.
-⋮----
-/**
-   * Promise-driven method to assert that a ws has been successfully authenticated (will await until auth is confirmed)
-   */
-public async assertIsAuthenticated(wsKey: TWSKey): Promise<unknown>
-⋮----
-// Already in progress? Await shared promise and retry
-⋮----
-// this.logger.trace('assertIsAuthenticated(): ok');
-⋮----
-// Start authentication, it should automatically store/return a promise.
-
-================
-File: README.md
-================
-# Node.js & JavaScript SDK for Gate.com (Gate.io) REST APIs, WebSockets & WebSocket API
-
-<p align="center">
-  <a href="https://www.npmjs.com/package/gateio-api">
-    <picture>
-      <source media="(prefers-color-scheme: dark)" srcset="https://github.com/tiagosiebler/gateio-api/blob/master/docs/images/logoDarkMode2.svg?raw=true#gh-dark-mode-only">
-      <img alt="SDK Logo" src="https://github.com/tiagosiebler/gateio-api/blob/master/docs/images/logoBrightMode2.svg?raw=true#gh-light-mode-only">
-    </picture>
-  </a>
-</p>
-
-[![npm version](https://img.shields.io/npm/v/gateio-api)][1]
-[![npm size](https://img.shields.io/bundlephobia/min/gateio-api/latest)][1]
-[![npm downloads](https://img.shields.io/npm/dt/gateio-api)][1]
-[![Build & Test](https://github.com/tiagosiebler/gateio-api/actions/workflows/e2etest.yml/badge.svg?branch=master)](https://github.com/tiagosiebler/gateio-api/actions/workflows/e2etest.yml)
-[![last commit](https://img.shields.io/github/last-commit/tiagosiebler/gateio-api)][1]
-[![Telegram](https://img.shields.io/badge/chat-on%20telegram-blue.svg)](https://t.me/nodetraders)
-
-[1]: https://www.npmjs.com/package/gateio-api
-
-Updated & performant JavaScript & Node.js SDK for the Gate.com (gate.io) REST APIs and WebSockets:
-
-- Professional, robust & performant Gate.com SDK with extensive production use in live trading environments.
-- Extensive integration with Gate.com (Gate.io) REST APIs and WebSockets.
-- Complete TypeScript support (with type declarations for most API requests & responses).
-  - Strongly typed requests and responses.
-  - Automated end-to-end tests ensuring reliability.
-- Actively maintained with a modern, promise-driven interface.
-- Gate.com REST APIs for Gate.com Spot, Margin, Perpetual Futures, Delivery Futures, Options & Announcements APIs.
-  - Unified RestClient for all Gate.com trading products.
-  - Strongly typed on most requests and responses.
-- Support for seamless API authentication for private Gate.com REST API and WebSocket calls.
-- Robust WebSocket integration with configurable connection heartbeats & automatic reconnect then resubscribe workflows.
-  - Event driven messaging.
-  - Smart websocket persistence with automatic reconnection handling.
-    - Automatically handle silent websocket disconnections through timed heartbeats, including the scheduled 24hr disconnect.
-    - Automatically handle listenKey persistence and expiration/refresh.
-    - Emit `reconnected` event when dropped connection is restored.
-  - Support for Gate.com Spot, Margin, Perpetual Futures, Delivery Futures & Options.
-- WebSocket API for Gate.com Spot, Margin, Perpetual Futures & Delivery Futures.
-  - Automatic connectivity via existing WebsocketClient, just call sendWSAPIRequest to trigger a request.
-  - Automatic authentication, just call sendWSAPIRequest with channel & parameters.
-  - Choose between two interfaces for WS API communication:
-    - Event-driven interface, fire & forget via sendWSAPIRequest and receive async replies via wsClient's event emitter.
-    - Promise-driven interface, simply use the WebsocketAPIClient for a REST-like experience. Use the WebSocket API like a REST API! See [examples/ws-api-client.ts](./examples/ws-api-client.ts) for a demonstration.
-- Heavy automated end-to-end testing with real API calls.
-- Proxy support via axios integration.
-- Active community support & collaboration in telegram: [Node.js Algo Traders](https://t.me/nodetraders).
-
-## Table of Contents
-
-- [Installation](#installation)
-- [Examples](#examples)
-- [Issues & Discussion](#issues--discussion)
-- [Related Projects](#related-projects)
-- [Documentation](#documentation)
-- [Structure](#structure)
-- [Usage](#usage)
-  - [REST API Client](#rest-api)
-  - [WebSocket Client](#websockets)
-    - [WebSocket Data Streams](#websocket-data-streams)
-    - [WebSocket API](#websocket-api)
-      - [Event Driven API](#event-driven-api)
-      - [REST-like API](#rest-like-api)
-- [Customise Logging](#customise-logging)
-- [LLMs & AI](#use-with-llms--ai)
-- [Used By](#used-by)
-- [Contributions & Thanks](#contributions--thanks)
-
-## Installation
-
-`npm install --save gateio-api`
-
-## Examples
-
-Refer to the [examples](./examples) folder for implementation demos, including:
-
-- **REST API Examples**: spot trading, futures trading, account management
-- **WebSocket Examples**: public market data streams, private account data, WebSocket API usage
-- **Spot Trading**: comprehensive spot market examples
-- **Futures Trading**: perpetual and delivery futures examples
-- **WebSocket API**: both event-driven and promise-driven approaches
-
-## Issues & Discussion
-
-- Issues? Check the [issues tab](https://github.com/tiagosiebler/gateio-api/issues).
-- Discuss & collaborate with other node devs? Join our [Node.js Algo Traders](https://t.me/nodetraders) engineering community on telegram.
-- Follow our announcement channel for real-time updates on [X/Twitter](https://x.com/sieblyio)
-
-<!-- template_related_projects -->
-
-## Related projects
-
-Check out my related JavaScript/TypeScript/Node.js projects:
-
-- Try my REST API & WebSocket SDKs:
-  - [Bybit-api Node.js SDK](https://www.npmjs.com/package/bybit-api)
-  - [Okx-api Node.js SDK](https://www.npmjs.com/package/okx-api)
-  - [Binance Node.js SDK](https://www.npmjs.com/package/binance)
-  - [Gateio-api Node.js SDK](https://www.npmjs.com/package/gateio-api)
-  - [Bitget-api Node.js SDK](https://www.npmjs.com/package/bitget-api)
-  - [Kucoin-api Node.js SDK](https://www.npmjs.com/package/kucoin-api)
-  - [Coinbase-api Node.js SDK](https://www.npmjs.com/package/coinbase-api)
-  - [Bitmart-api Node.js SDK](https://www.npmjs.com/package/bitmart-api)
-- Try my misc utilities:
-  - [OrderBooks Node.js](https://www.npmjs.com/package/orderbooks)
-  - [Crypto Exchange Account State Cache](https://www.npmjs.com/package/accountstate)
-- Check out my examples:
-  - [awesome-crypto-examples Node.js](https://github.com/tiagosiebler/awesome-crypto-examples)
-  <!-- template_related_projects_end -->
-
-## Documentation
-
-Most methods accept JS objects. These can be populated using parameters specified by Gate.com's API documentation, or check the type definition in each class within this repository.
-
-### API Documentation Links
-
-- [Gate.com/gate.io API Documentation](https://www.gate.com/docs/developers/apiv4/en/)
-  - [Spot Trading API](https://www.gate.com/docs/developers/apiv4/en/#spot-new)
-  - [Margin Trading API](https://www.gate.com/docs/developers/apiv4/en/#margin-new)
-  - [Futures Trading API](https://www.gate.com/docs/developers/apiv4/en/#futures-new)
-  - [Options Trading API](https://www.gate.com/docs/developers/apiv4/en/#options-new)
-  - [WebSocket API](https://www.gate.com/docs/developers/apiv4/en/#websocket-api)
-- [REST Endpoint Function List](./docs/endpointFunctionList.md)
-- [TSDoc Documentation (autogenerated using typedoc)](https://tsdocs.dev/docs/gateio-api)
-
-## Structure
-
-This project uses typescript. Resources are stored in 2 key structures:
-
-- [src](./src) - the whole connector written in typescript
-- [examples](./examples) - some implementation examples & demonstrations. Contributions are welcome!
-
----
-
-# Usage
-
-Create API credentials on Gate.com's website:
-
-- [Gate.com API Key Management](https://www.gate.com/myaccount/api_key_manage)
-
-## REST API
-
-The SDK provides a unified `RestClient` for all Gate.com trading products including Spot, Margin, Perpetual Futures, Delivery Futures, and Options. This single client handles all REST API operations across all trading markets.
-
-To use any of Gate.com's REST APIs in JavaScript/TypeScript/Node.js, import (or require) the `RestClient`:
-
-```javascript
-const { RestClient } = require('gateio-api');
-
-const API_KEY = 'xxx';
-const PRIVATE_KEY = 'yyy';
-
-const client = new RestClient({
-  apiKey: API_KEY,
-  apiSecret: PRIVATE_KEY,
-});
-
-client
-  .getSpotTicker()
-  .then((result) => {
-    console.log('all spot tickers result: ', result);
-  })
-  .catch((err) => {
-    console.error('spot ticker error: ', err);
-  });
-
-client
-  .getSpotOrders({
-    currency_pair: 'BTC_USDT', // Specify the currency pair
-    status: 'open', // Specify the status of the orders to fetch
-  })
-  .then((result) => {
-    console.log('getSpotOrders result: ', result);
-  })
-  .catch((err) => {
-    console.error('getSpotOrders error: ', err);
-  });
-```
-
-See [RestClient](./src/RestClient.ts) for further information, or the [examples](./examples/) for lots of usage examples.
-
-## WebSockets
-
-All WebSocket functionality is supported via the unified `WebsocketClient`. This client handles all Gate.com WebSocket streams with automatic connection management and reconnection.
-
-Key WebSocket features:
-
-- Event driven messaging
-- Smart WebSocket persistence with automatic reconnection
-- Heartbeat mechanisms to detect disconnections
-- Automatic resubscription after reconnection
-- Support for all Gate.com trading products (Spot, Margin, Futures, Options)
-- WebSocket API support for real-time trading operations
-
-### WebSocket Data Streams
-
-All available WebSockets can be used via a shared `WebsocketClient`. The WebSocket client will automatically open/track/manage connections as needed. Each unique connection (one per server URL) is tracked using a WsKey (each WsKey is a string - see [WS_KEY_MAP](src/lib/websocket/websocket-util.ts) for a list of supported values).
-
-Any subscribe/unsubscribe events will need to include a WsKey, so the WebSocket client understands which connection the event should be routed to. See examples below or in the [examples](./examples/) folder on GitHub.
-
-Data events are emitted from the WebsocketClient via the `update` event, see example below:
-
-```javascript
-const { WebsocketClient } = require('gateio-api');
-
-const API_KEY = 'xxx';
-const PRIVATE_KEY = 'yyy';
-
-const wsConfig = {
-  apiKey: API_KEY,
-  apiSecret: PRIVATE_KEY,
-
-  /*
-    The following parameters are optional:
-  */
-
-  // Livenet is used by default, use this to enable testnet:
-  // useTestnet: true
-
-  // how long to wait (in ms) before deciding the connection should be terminated & reconnected
-  // pongTimeout: 1000,
-
-  // how often to check (in ms) that WS connection is still alive
-  // pingInterval: 10000,
-
-  // how long to wait before attempting to reconnect (in ms) after connection is closed
-  // reconnectTimeout: 500,
-
-  // config options sent to RestClient (used for time sync). See RestClient docs.
-  // restOptions: { },
-
-  // config for axios used for HTTP requests. E.g for proxy support
-  // requestOptions: { }
-};
-
-const ws = new WebsocketClient(wsConfig);
-
-/**
- * Subscribing to data:
- **/
-
-const userOrders = {
-  topic: 'spot.orders',
-  payload: ['BTC_USDT', 'ETH_USDT', 'MATIC_USDT'],
-};
-
-const userTrades = {
-  topic: 'spot.usertrades',
-  payload: ['BTC_USDT', 'ETH_USDT', 'MATIC_USDT'],
-};
-
-const userPriceOrders = {
-  topic: 'spot.priceorders',
-  payload: ['!all'],
-};
-
-// subscribe to multiple topics at once
-ws.subscribe([userOrders, userTrades, userPriceOrders], 'spotV4');
-
-// and/or subscribe to individual topics on demand
-ws.subscribe(
-  {
-    topic: 'spot.priceorders',
-    payload: ['!all'],
-  },
-  'spotV4',
-);
-
-// Some topics don't need params, for those you can just subscribe with a string (or use a topic + payload object as above)
-ws.subscribe('spot.balances', 'spotV4');
-
-/**
- * Handling events:
- **/
-
-// Listen to events coming from websockets. This is the primary data source
-ws.on('update', (data) => {
-  console.log('data', data);
-});
-
-// Optional: Listen to websocket connection open event (automatic after subscribing to one or more topics)
-ws.on('open', ({ wsKey, event }) => {
-  console.log('connection open for websocket with ID: ' + wsKey);
-});
-
-// Optional: Listen to responses to websocket queries (e.g. the reply after subscribing to a topic)
-ws.on('response', (response) => {
-  console.log('response', response);
-});
-
-// Optional: Listen to connection close event. Unexpected connection closes are automatically reconnected.
-ws.on('close', () => {
-  console.log('connection closed');
-});
-
-// Optional: listen to internal exceptions. Useful for debugging if something weird happens
-ws.on('exception', (data) => {
-  console.error('exception: ', data);
-});
-
-// Optional: Listen to raw error events.
-ws.on('error', (err) => {
-  console.error('ERR', err);
-});
-```
-
-See [WebsocketClient](./src/WebsocketClient.ts) for further information and make sure to check the [examples](./examples/) folder for much more detail.
-
-### Websocket API
-
-Gate.com supports sending requests (commands) over an active WebSocket connection. This is called the WebSocket API.
-
-The WebSocket API is available through two approaches, depending on individual preference:
-
-#### Event Driven API
-
-The WebSocket API is available in the [WebsocketClient](./src/WebsocketClient.ts) via the `sendWSAPIRequest(wsKey, channel, params)` method.
-
-Each call to this method is wrapped in a promise, which you can async await for a response, or handle it in a raw event-driven design.
-
-- event-driven:
-  - send requests via `client.sendWSAPIRequest(wsKey, channel, params).catch(e => console.error('WS API exception for channel', channel, e))`, fire and forget, don't use await
-  - handle async replies via event handlers on `client.on('exception', cb)` and `client.on('response', cb)`
-- promise-driven:
-  - send requests via `const result = await client.sendWSAPIRequest(wsKey, channel, params)`, which returns a promise
-  - await each call
-  - use try/catch blocks to handle promise rejections
-
-#### REST-like API
-
-The WebSocket API is also available in a promise-wrapped REST-like format. Either, as above, await any calls to `sendWSAPIRequest(...)`, or directly use the convenient WebsocketAPIClient. This class is very similar to existing REST API classes (such as the RestClient).
-
-It provides one function per endpoint, feels like a REST API and will automatically route your request via an automatically persisted, authenticated and health-checked WebSocket API connection.
-
-Below is an example showing how easy it is to use the WebSocket API without any concern for the complexity of managing WebSockets.
-
-```javascript
-const { WebsocketAPIClient } = require('gateio-api');
-
-const API_KEY = 'xxx';
-const API_SECRET = 'yyy';
-
-async function start() {
-  // Make an instance of the WS API Client
-  const wsClient = new WebsocketAPIClient({
-    apiKey: API_KEY,
-    apiSecret: API_SECRET,
-    // Automatically re-auth WS API, if we were auth'd before and get reconnected
-    reauthWSAPIOnReconnect: true,
-  });
-
-  try {
-    // Connection will authenticate automatically before first request
-    // Make WebSocket API calls, very similar to a REST API:
-
-    /* ============ SPOT TRADING EXAMPLES ============ */
-
-    // Submit a new spot order
-    const newOrder = await wsClient.submitNewSpotOrder({
-      text: 't-my-custom-id',
-      currency_pair: 'BTC_USDT',
-      type: 'limit',
-      account: 'spot',
-      side: 'buy',
-      amount: '1',
-      price: '10000',
-    });
-    console.log('Order result:', newOrder.data);
-
-    // Cancel a spot order
-    const cancelOrder = await wsClient.cancelSpotOrder({
-      order_id: '1700664330',
-      currency_pair: 'BTC_USDT',
-      account: 'spot',
-    });
-    console.log('Cancel result:', cancelOrder.data);
-
-    // Get spot order status
-    const orderStatus = await wsClient.getSpotOrderStatus({
-      order_id: '1700664330',
-      currency_pair: 'BTC_USDT',
-      account: 'spot',
-    });
-    console.log('Order status:', orderStatus.data);
-
-    /* ============ FUTURES TRADING EXAMPLES ============ */
-
-    // Submit a new futures order
-    const newFuturesOrder = await wsClient.submitNewFuturesOrder({
-      contract: 'BTC_USDT',
-      size: 10,
-      price: '31503.28',
-      tif: 'gtc',
-      text: 't-my-custom-id',
-    });
-    console.log('Futures order result:', newFuturesOrder.data);
-
-    // Cancel a futures order
-    const cancelFuturesOrder = await wsClient.cancelFuturesOrder({
-      order_id: '74046514',
-    });
-    console.log('Cancel futures order result:', cancelFuturesOrder.data);
-
-    // Get futures order status
-    const futuresOrderStatus = await wsClient.getFuturesOrderStatus({
-      order_id: '74046543',
-    });
-    console.log('Futures order status:', futuresOrderStatus.data);
-  } catch (e) {
-    console.error('WS API Error:', e);
-  }
+// Used for spot and flash swap
+export interface CurrencyPair {
+  id?: string;
+  base?: string;
+  base_name?: string;
+  quote?: string;
+  quote_name?: string;
+  fee?: string;
+  min_base_amount?: string;
+  min_quote_amount?: string;
+  max_base_amount?: string;
+  max_quote_amount?: string;
+  amount_precision?: number;
+  precision?: number;
+  trade_status?: 'untradable' | 'buyable' | 'sellable' | 'tradable';
+  sell_start?: number;
+  buy_start?: number;
+  type: string;
+  delisting_time?: number;
+  trade_url?: string;
 }
 
-start();
-```
-
-For more detailed examples using any approach, refer to the [examples](./examples/) folder (e.g. [ws-api-client.ts](./examples/ws-api-client.ts)).
-
----
-
-## Customise Logging
-
-Pass a custom logger which supports the log methods `silly`, `debug`, `notice`, `info`, `warning` and `error`, or override methods from the default logger as desired.
-
-```javascript
-const { WebsocketClient, DefaultLogger } = require('gateio-api');
-
-// Disable all logging on the silly level
-DefaultLogger.silly = () => {};
-
-const ws = new WebsocketClient({ key: 'xxx', secret: 'yyy' }, DefaultLogger);
-```
-
-## Use with LLMs & AI
-
-This SDK includes a bundled `llms.txt` file in the root of the repository. If you're developing with LLMs, use the included `llms.txt` with your LLM - it will significantly improve the LLMs understanding of how to correctly use this SDK.
-
-This file contains AI optimised structure of all the functions in this package, and their parameters for easier use with any learning models or artificial intelligence.
-
----
-
-## Used By
-
-[![Repository Users Preview Image](https://dependents.info/tiagosiebler/gateio-api/image)](https://github.com/tiagosiebler/gateio-api/network/dependents)
-
----
-
-<!-- template_contributions -->
-
-### Contributions & Thanks
-
-Have my projects helped you? Share the love, there are many ways you can show your thanks:
-
-- Star & share my projects.
-- Are my projects useful? Sponsor me on Github and support my effort to maintain & improve them: https://github.com/sponsors/tiagosiebler
-- Have an interesting project? Get in touch & invite me to it.
-- Or buy me all the coffee:
-  - ETH(ERC20): `0xA3Bda8BecaB4DCdA539Dc16F9C54a592553Be06C` <!-- metamask -->
-
-<!---
-old ones:
-  - BTC: `1C6GWZL1XW3jrjpPTS863XtZiXL1aTK7Jk`
-  - BTC(SegWit): `bc1ql64wr9z3khp2gy7dqlmqw7cp6h0lcusz0zjtls`
-  - ETH(ERC20): `0xe0bbbc805e0e83341fadc210d6202f4022e50992`
-  - USDT(TRC20): `TA18VUywcNEM9ahh3TTWF3sFpt9rkLnnQa
--->
-<!-- template_contributions_end -->
-
-### Contributions & Pull Requests
-
-Contributions are encouraged, I will review any incoming pull requests. See the issues tab for todo items.
-
-<!-- template_star_history -->
-
-## Star History
-
-[![Star History Chart](https://api.star-history.com/svg?repos=tiagosiebler/bybit-api,tiagosiebler/okx-api,tiagosiebler/binance,tiagosiebler/bitget-api,tiagosiebler/bitmart-api,tiagosiebler/gateio-api,tiagosiebler/kucoin-api,tiagosiebler/coinbase-api,tiagosiebler/orderbooks,tiagosiebler/accountstate,tiagosiebler/awesome-crypto-examples&type=Date)](https://star-history.com/#tiagosiebler/bybit-api&tiagosiebler/okx-api&tiagosiebler/binance&tiagosiebler/bitget-api&tiagosiebler/bitmart-api&tiagosiebler/gateio-api&tiagosiebler/kucoin-api&tiagosiebler/coinbase-api&tiagosiebler/orderbooks&tiagosiebler/accountstate&tiagosiebler/awesome-crypto-examples&Date)
-
-<!-- template_star_history_end -->
+================
+File: src/index.ts
+================
+// Request Types
+⋮----
+// Response Types
+⋮----
+// Websockets Types
+⋮----
+// Shared Types
 
 ================
 File: src/RestClient.ts
@@ -7699,6 +6678,7 @@ import {
   UpdateDualModePositionLeverageReq,
   UpdateDualModePositionMarginReq,
   UpdateFuturesOrderReq,
+  UpdateFuturesPriceTriggeredOrderReq,
 } from './types/request/futures.js';
 import {
   GetCrossMarginAccountHistoryReq,
@@ -7788,6 +6768,7 @@ import {
 import { SubmitWithdrawalReq } from './types/request/withdrawal.js';
 import {
   AccountDetail,
+  AccountMainKey,
   AccountRateLimit,
   StpGroup,
   StpGroupUser,
@@ -7945,6 +6926,7 @@ import {
 import {
   CreateDepositAddressResp,
   CurrencyChain,
+  DepositRecord,
   GetBalancesResp,
   PushOrder,
   SavedAddress,
@@ -8034,7 +7016,7 @@ submitSpotMainAccountTransfer(params: {
    * Cancel withdrawal with specified ID
    *
    * @param params Parameters containing the withdrawal ID
-   * @returns Promise<Withdraw>
+   * @returns Promise<WithdrawalRecord>
    */
 cancelWithdrawal(params: {
     withdrawal_id: string;
@@ -8049,7 +7031,7 @@ cancelWithdrawal(params: {
    * List chains supported for specified currency
    *
    * @param params Parameters containing the currency name
-   * @returns Promise< GetCurrencyChainsResp[][]>
+   * @returns Promise<CurrencyChain[]>
    */
 getCurrencyChains(params:
 ⋮----
@@ -8081,11 +7063,11 @@ getWithdrawalRecords(
    * Record time range cannot exceed 30 days
    *
    * @param params Parameters for filtering deposit records
-   * @returns Promise<Withdraw[]>
+   * @returns Promise<DepositRecord[]>
    */
 getDepositRecords(
     params?: GetWithdrawalDepositRecordsReq,
-): Promise<WithdrawalRecord[]>
+): Promise<DepositRecord[]>
 ⋮----
 /**
    * Transfer between trading accounts
@@ -8154,7 +7136,7 @@ getTransferStatus(params: {
    * Retrieve withdrawal status
    *
    * @param params Parameters for retrieving withdrawal status
-   * @returns Promise<GetWithdrawalStatusResp[]>
+   * @returns Promise<WithdrawalStatus[]>
    */
 getWithdrawalStatus(params?: {
     currency?: string;
@@ -8396,9 +7378,8 @@ getSubAccountMode(): Promise<SubAccountMode>
    * Get unified account information
    *
    * The assets of each currency in the account will be adjusted according to their liquidity, defined by corresponding adjustment coefficients, and then uniformly converted to USD to calculate the total asset value and position value of the account.
-   *
    * @param params Parameters for retrieving unified account information
-   * @returns Promise<GetUnifiedAccountInfoResp>
+   * @returns Promise<UnifiedAccountInfo>
    */
 getUnifiedAccountInfo(params?: {
     currency?: string;
@@ -8442,6 +7423,8 @@ getUnifiedMaxTransferables(params: { currencies: string }): Promise<
     }[]
   > {
     return this.getPrivate('/unified/transferables', params);
+⋮----
+getUnifiedBatchMaxBorrowable(params:
 ⋮----
 /**
    * Borrow or repay
@@ -10052,6 +9035,16 @@ cancelFuturesPriceTriggeredOrder(params: {
     order_id: string;
 }): Promise<FuturesPriceTriggeredOrder>
 ⋮----
+/**
+   * Update a single price-triggered order
+   *
+   * @param params Parameters for updating a price-triggered order
+   * @returns Promise<{ id: number }>
+   */
+updateFuturesPriceTriggeredOrder(
+    params: UpdateFuturesPriceTriggeredOrderReq,
+): Promise<
+⋮----
 getFuturesPositionCloseHistory(
     params: GetFuturesPositionCloseHistoryReq,
 ): Promise<FuturesPositionHistoryRecord[]>
@@ -11018,17 +10011,14 @@ getMultiLoanCurrentRates(params: {
    */
 ⋮----
 /**
-   * ETH2 swap
-   *
-   * @param params Parameters for ETH2 swap
+   * ETH swap (formerly ETH2 swap)
+   * @param params Parameters for ETH swap (1 - ETH to GTETH, 2 - GTETH to ETH)
    * @returns Promise<any>
    */
 submitEth2Swap(params:
 ⋮----
 /**
-   * Get ETH2 historical rate of return data
-   *
-   * Returns the ETH earnings rate record for the last 31 days
+   * Get GTETH historical rate of return data (formerly ETH2)
    *
    * @returns Promise<Array<{date_time: number, date: string, rate: string}>>
    */
@@ -11209,6 +10199,13 @@ setGTDeduction(params:
    */
 getGTDeduction(): Promise<
 ⋮----
+/**
+   * Query all main account API key information
+   *
+   * @returns Promise<AccountMainKey[]>
+   */
+getAccountMainKeys(): Promise<AccountMainKey[]>
+⋮----
 /**==========================================================================================================================
    * REBATES
    * ==========================================================================================================================
@@ -11311,6 +10308,266 @@ getUserSubordinateRelationships(params: {
 }): Promise<
 ⋮----
 user_id_list: string; // Comma-separated list of user IDs (max 100)
+
+================
+File: src/WebsocketAPIClient.ts
+================
+import { DefaultLogger } from './lib/logger.js';
+import { WS_KEY_MAP } from './lib/websocket/websocket-util.js';
+import { WSClientConfigurableOptions } from './types/websockets/client.js';
+import {
+  WSAPIFuturesOrder,
+  WSAPIFuturesOrderAmendReq,
+  WSAPIFuturesOrderBatchPlaceRespItem,
+  WSAPIFuturesOrderCancelCPReq,
+  WSAPIFuturesOrderCancelIdsRespItem,
+  WSAPIFuturesOrderCancelReq,
+  WSAPIFuturesOrderListReq,
+  WSAPIFuturesOrderPlaceReq,
+  WSAPIFuturesOrderStatusReq,
+  WSAPIResponse,
+  WSAPISpotOrder,
+  WSAPISpotOrderAmendReq,
+  WSAPISpotOrderCancelCPReq,
+  WSAPISpotOrderCancelIdsReq,
+  WSAPISpotOrderCancelIdsRespItem,
+  WSAPISpotOrderCancelReq,
+  WSAPISpotOrderListReq,
+  WSAPISpotOrderPlaceReq,
+  WSAPISpotOrderStatusReq,
+  WSAPIWsKey,
+} from './types/websockets/wsAPI.js';
+import { WebsocketClient } from './WebsocketClient.js';
+⋮----
+/**
+ * Configurable options specific to only the REST-like WebsocketAPIClient
+ */
+export interface WSAPIClientConfigurableOptions {
+  /**
+   * Default: true
+   *
+   * Attach default event listeners, which will console log any high level
+   * events (opened/reconnecting/reconnected/etc).
+   *
+   * If you disable this, you should set your own event listeners
+   * on the embedded WS Client `wsApiClient.getWSClient().on(....)`.
+   */
+  attachEventListeners: boolean;
+}
+⋮----
+/**
+   * Default: true
+   *
+   * Attach default event listeners, which will console log any high level
+   * events (opened/reconnecting/reconnected/etc).
+   *
+   * If you disable this, you should set your own event listeners
+   * on the embedded WS Client `wsApiClient.getWSClient().on(....)`.
+   */
+⋮----
+/**
+ * This is a minimal Websocket API wrapper around the WebsocketClient.
+ *
+ * Some methods support passing in a custom "wsKey". This is a reference to which WS connection should
+ * be used to transmit that message. This is only useful if you wish to use an alternative wss
+ * domain that is supported by the SDK.
+ *
+ * Note: To use testnet, don't set the wsKey - use `testnet: true` in
+ * the constructor instead.
+ *
+ * Note: You can also directly use the sendWSAPIRequest() method to make WS API calls, but some
+ * may find the below methods slightly more intuitive.
+ *
+ * Refer to the WS API promises example for a more detailed example on using sendWSAPIRequest() directly:
+ * https://github.com/tiagosiebler/gateio-api/blob/master/examples/ws-private-spot-wsapi.ts#L119
+ */
+export class WebsocketAPIClient
+⋮----
+constructor(
+    options?: WSClientConfigurableOptions &
+      Partial<WSAPIClientConfigurableOptions>,
+    logger?: DefaultLogger,
+)
+⋮----
+public getWSClient(): WebsocketClient
+⋮----
+public setTimeOffsetMs(newOffset: number): void
+⋮----
+/*
+   *
+   * SPOT - Trading requests
+   *
+   */
+⋮----
+/**
+   * Submit a spot order
+   */
+submitNewSpotOrder(
+    params: WSAPISpotOrderPlaceReq,
+    wsKey?: WSAPIWsKey,
+): Promise<WSAPIResponse<WSAPISpotOrder>>
+⋮----
+/**
+   * Cancel a spot order
+   */
+cancelSpotOrder(
+    params: WSAPISpotOrderCancelReq,
+    wsKey?: WSAPIWsKey,
+): Promise<WSAPIResponse<WSAPISpotOrder>>
+⋮----
+/**
+   * Cancel all spot orders with the given id list
+   */
+cancelSpotOrderById(
+    params: WSAPISpotOrderCancelIdsReq[],
+    wsKey?: WSAPIWsKey,
+): Promise<WSAPIResponse<WSAPISpotOrderCancelIdsRespItem[]>>
+⋮----
+/**
+   * Cancel a spot order for a given symbol
+   */
+cancelSpotOrderForSymbol(
+    params: WSAPISpotOrderCancelCPReq,
+    wsKey?: WSAPIWsKey,
+): Promise<WSAPIResponse<WSAPISpotOrder[]>>
+⋮----
+/**
+   * Update a spot order
+   */
+updateSpotOrder(
+    params: WSAPISpotOrderAmendReq,
+    wsKey?: WSAPIWsKey,
+): Promise<WSAPIResponse<WSAPISpotOrder>>
+⋮----
+/**
+   * Get the status of a spot order
+   */
+getSpotOrderStatus(
+    params: WSAPISpotOrderStatusReq,
+    wsKey?: WSAPIWsKey,
+): Promise<WSAPIResponse<WSAPISpotOrder>>
+⋮----
+/**
+   * Get all spot orders
+   */
+getSpotOrders(
+    params: WSAPISpotOrderListReq,
+    wsKey?: WSAPIWsKey,
+): Promise<WSAPIResponse<WSAPISpotOrder[]>>
+⋮----
+/*
+   *
+   * Futures - Trading requests
+   *
+   */
+⋮----
+/**
+   * Submit a futures order.
+   *
+   * Note: without a wsKey, this defaults to the perpFuturesUSDTV4 connection
+   */
+submitNewFuturesOrder(
+    params: WSAPIFuturesOrderPlaceReq,
+    wsKey?: WSAPIWsKey,
+): Promise<WSAPIResponse<WSAPIFuturesOrder>>
+⋮----
+/**
+   * Submit a batch of futures orders
+   *
+   * Note: without a wsKey, this defaults to the perpFuturesUSDTV4 connection
+   */
+submitNewFuturesBatchOrder(
+    params: WSAPIFuturesOrderPlaceReq[],
+    wsKey?: WSAPIWsKey,
+): Promise<WSAPIResponse<WSAPIFuturesOrderBatchPlaceRespItem[]>>
+⋮----
+/**
+   * Cancel a futures order
+   *
+   * Note: without a wsKey, this defaults to the perpFuturesUSDTV4 connection
+   */
+cancelFuturesOrder(
+    params: WSAPIFuturesOrderCancelReq,
+    wsKey?: WSAPIWsKey,
+): Promise<WSAPIResponse<WSAPIFuturesOrder>>
+⋮----
+/**
+   * Cancel futures orders by id list
+   *
+   * Note: without a wsKey, this defaults to the perpFuturesUSDTV4 connection
+   */
+cancelFuturesOrderById(
+    params: string[],
+    wsKey?: WSAPIWsKey,
+): Promise<WSAPIResponse<WSAPIFuturesOrderCancelIdsRespItem[]>>
+⋮----
+/**
+   * Cancel all open futures orders
+   *
+   * Note: without a wsKey, this defaults to the perpFuturesUSDTV4 connection
+   */
+cancelFuturesAllOpenOrders(
+    params: WSAPIFuturesOrderCancelCPReq,
+    wsKey?: WSAPIWsKey,
+): Promise<WSAPIResponse<WSAPIFuturesOrder[]>>
+⋮----
+/**
+   * Update a futures order
+   *
+   * Note: without a wsKey, this defaults to the perpFuturesUSDTV4 connection
+   */
+updateFuturesOrder(
+    params: WSAPIFuturesOrderAmendReq,
+    wsKey?: WSAPIWsKey,
+): Promise<WSAPIResponse<WSAPIFuturesOrder>>
+⋮----
+/**
+   * Get all futures orders
+   *
+   * Note: without a wsKey, this defaults to the perpFuturesUSDTV4 connection
+   */
+getFuturesOrders(
+    params: WSAPIFuturesOrderListReq,
+    wsKey?: WSAPIWsKey,
+): Promise<WSAPIResponse<WSAPIFuturesOrder[]>>
+⋮----
+/**
+   * Get futures order status
+   *
+   * Note: without a wsKey, this defaults to the perpFuturesUSDTV4 connection
+   */
+getFuturesOrderStatus(
+    params: WSAPIFuturesOrderStatusReq,
+    wsKey?: WSAPIWsKey,
+): Promise<WSAPIResponse<WSAPIFuturesOrder>>
+⋮----
+/**
+   *
+   *
+   *
+   *
+   *
+   *
+   *
+   * Private methods for handling some of the convenience/automation provided by the WS API Client
+   *
+   *
+   *
+   *
+   *
+   *
+   *
+   */
+⋮----
+private setupDefaultEventListeners()
+⋮----
+/**
+       * General event handlers for monitoring the WebsocketClient
+       */
+⋮----
+// Blind JSON.stringify can fail on circular references
+⋮----
+// JSON.stringify({ ...data, target: 'WebSocket' }),
 
 ================
 File: src/WebsocketClient.ts
@@ -11610,11 +10867,269 @@ private async signWSAPIRequest<TRequestParams = object>(
 ): Promise<WSAPIRequest<TRequestParams>>
 
 ================
+File: .eslintrc.cjs
+================
+// 'no-unused-vars': ['warn'],
+
+================
+File: .gitignore
+================
+!.gitkeep
+.DS_STORE
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+lerna-debug.log*
+report.[0-9]*.[0-9]*.[0-9]*.[0-9]*.json
+pids
+*.pid
+*.seed
+*.pid.lock
+node_modules/
+.npm
+.eslintcache
+.node_repl_history
+*.tgz
+.yarn-integrity
+.env
+.env.test
+.cache
+bundleReport.html
+.history/
+dist
+coverage
+localtest.sh
+repomix.sh
+
+ws-private-spot-wsapi-performance.ts
+ws-private-perp-futures-wsapi-readonly.ts
+privatetest.ts
+
+privaterepotracker
+restClientRegex.ts
+
+testfile.ts
+
+================
+File: .nvmrc
+================
+v22.17.0
+
+================
+File: .prettierrc
+================
+{
+  "tabWidth": 2,
+  "singleQuote": true,
+  "trailingComma": "all"
+}
+
+================
+File: jest.config.ts
+================
+/**
+ * For a detailed explanation regarding each configuration property, visit:
+ * https://jestjs.io/docs/configuration
+ */
+⋮----
+import type { Config } from 'jest';
+⋮----
+// All imported modules in your tests should be mocked automatically
+// automock: false,
+⋮----
+// Stop running tests after `n` failures
+// bail: 0,
+bail: false, // enable to stop test when an error occur,
+⋮----
+// The directory where Jest should store its cached dependency information
+// cacheDirectory: "/private/var/folders/kf/2k3sz4px6c9cbyzj1h_b192h0000gn/T/jest_dx",
+⋮----
+// Automatically clear mock calls, instances, contexts and results before every test
+⋮----
+// Indicates whether the coverage information should be collected while executing the test
+⋮----
+// An array of glob patterns indicating a set of files for which coverage information should be collected
+⋮----
+// The directory where Jest should output its coverage files
+⋮----
+// An array of regexp pattern strings used to skip coverage collection
+// coveragePathIgnorePatterns: [
+//   "/node_modules/"
+// ],
+⋮----
+// Indicates which provider should be used to instrument code for coverage
+⋮----
+// A list of reporter names that Jest uses when writing coverage reports
+// coverageReporters: [
+//   "json",
+//   "text",
+//   "lcov",
+//   "clover"
+// ],
+⋮----
+// An object that configures minimum threshold enforcement for coverage results
+// coverageThreshold: undefined,
+⋮----
+// A path to a custom dependency extractor
+// dependencyExtractor: undefined,
+⋮----
+// Make calling deprecated APIs throw helpful error messages
+// errorOnDeprecated: false,
+⋮----
+// The default configuration for fake timers
+// fakeTimers: {
+//   "enableGlobally": false
+// },
+⋮----
+// Force coverage collection from ignored files using an array of glob patterns
+// forceCoverageMatch: [],
+⋮----
+// A path to a module which exports an async function that is triggered once before all test suites
+// globalSetup: undefined,
+⋮----
+// A path to a module which exports an async function that is triggered once after all test suites
+// globalTeardown: undefined,
+⋮----
+// A set of global variables that need to be available in all test environments
+// globals: {},
+⋮----
+// The maximum amount of workers used to run your tests. Can be specified as % or a number. E.g. maxWorkers: 10% will use 10% of your CPU amount + 1 as the maximum worker number. maxWorkers: 2 will use a maximum of 2 workers.
+// maxWorkers: "50%",
+⋮----
+// An array of directory names to be searched recursively up from the requiring module's location
+// moduleDirectories: [
+//   "node_modules"
+// ],
+⋮----
+// An array of file extensions your modules use
+⋮----
+// modulePaths: ['src'],
+⋮----
+// A map from regular expressions to module names or to arrays of module names that allow to stub out resources with a single module
+// moduleNameMapper: {},
+⋮----
+// An array of regexp pattern strings, matched against all module paths before considered 'visible' to the module loader
+// modulePathIgnorePatterns: [],
+⋮----
+// Activates notifications for test results
+// notify: false,
+⋮----
+// An enum that specifies notification mode. Requires { notify: true }
+// notifyMode: "failure-change",
+⋮----
+// A preset that is used as a base for Jest's configuration
+// preset: undefined,
+⋮----
+// Run tests from one or more projects
+// projects: undefined,
+⋮----
+// Use this configuration option to add custom reporters to Jest
+// reporters: undefined,
+⋮----
+// Automatically reset mock state before every test
+// resetMocks: false,
+⋮----
+// Reset the module registry before running each individual test
+// resetModules: false,
+⋮----
+// A path to a custom resolver
+// resolver: undefined,
+⋮----
+// Automatically restore mock state and implementation before every test
+// restoreMocks: false,
+⋮----
+// The root directory that Jest should scan for tests and modules within
+// rootDir: undefined,
+⋮----
+// A list of paths to directories that Jest should use to search for files in
+// roots: [
+//   "<rootDir>"
+// ],
+⋮----
+// Allows you to use a custom runner instead of Jest's default test runner
+// runner: "jest-runner",
+⋮----
+// The paths to modules that run some code to configure or set up the testing environment before each test
+// setupFiles: [],
+⋮----
+// A list of paths to modules that run some code to configure or set up the testing framework before each test
+// setupFilesAfterEnv: [],
+⋮----
+// The number of seconds after which a test is considered as slow and reported as such in the results.
+// slowTestThreshold: 5,
+⋮----
+// A list of paths to snapshot serializer modules Jest should use for snapshot testing
+// snapshotSerializers: [],
+⋮----
+// The test environment that will be used for testing
+// testEnvironment: "jest-environment-node",
+⋮----
+// Options that will be passed to the testEnvironment
+// testEnvironmentOptions: {},
+⋮----
+// Adds a location field to test results
+// testLocationInResults: false,
+⋮----
+// The glob patterns Jest uses to detect test files
+⋮----
+// "**/__tests__/**/*.[jt]s?(x)",
+⋮----
+// An array of regexp pattern strings that are matched against all test paths, matched tests are skipped
+// testPathIgnorePatterns: [
+//   "/node_modules/"
+// ],
+⋮----
+// The regexp pattern or array of patterns that Jest uses to detect test files
+// testRegex: [],
+⋮----
+// This option allows the use of a custom results processor
+// testResultsProcessor: undefined,
+⋮----
+// This option allows use of a custom test runner
+// testRunner: "jest-circus/runner",
+⋮----
+// A map from regular expressions to paths to transformers
+// transform: undefined,
+⋮----
+// An array of regexp pattern strings that are matched against all source file paths, matched files will skip transformation
+// transformIgnorePatterns: [
+//   "/node_modules/",
+//   "\\.pnp\\.[^\\/]+$"
+// ],
+⋮----
+// Prevents import esm module error from v1 axios release, issue #5026
+⋮----
+// An array of regexp pattern strings that are matched against all modules before the module loader will automatically return a mock for them
+// unmockedModulePathPatterns: undefined,
+⋮----
+// Indicates whether each individual test should be reported during the run
+// verbose: undefined,
+verbose: true, // report individual test
+⋮----
+// An array of regexp patterns that are matched against all source file paths before re-running tests in watch mode
+// watchPathIgnorePatterns: [],
+⋮----
+// Whether to use watchman for file crawling
+// watchman: true,
+
+================
+File: LICENSE.md
+================
+Copyright 2022 Tiago Siebler
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+================
 File: package.json
 ================
 {
   "name": "gateio-api",
-  "version": "1.2.10",
+  "version": "1.3.1",
   "description": "Complete & Robust Node.js SDK for Gate.com's REST APIs, WebSockets & WebSocket APIs, with TypeScript declarations.",
   "scripts": {
     "clean": "rm -rf dist/*",
@@ -11704,6 +11219,605 @@ File: package.json
     "url": "https://github.com/tiagosiebler/gateio-api/issues"
   },
   "homepage": "https://github.com/tiagosiebler/gateio-api#readme"
+}
+
+================
+File: postBuild.sh
+================
+#!/bin/bash
+#
+#   Add package.json files to cjs/mjs subtrees
+#
+
+cat >dist/cjs/package.json <<!EOF
+{
+    "type": "commonjs"
+}
+!EOF
+
+cat >dist/mjs/package.json <<!EOF
+{
+    "type": "module"
+}
+!EOF
+
+find src -name '*.d.ts' -exec cp {} dist/mjs \;
+find src -name '*.d.ts' -exec cp {} dist/cjs \;
+
+================
+File: README.md
+================
+# Node.js & JavaScript SDK for Gate.com (Gate.io) REST APIs, WebSockets & WebSocket API
+
+<p align="center">
+  <a href="https://www.npmjs.com/package/gateio-api">
+    <picture>
+      <source media="(prefers-color-scheme: dark)" srcset="https://github.com/tiagosiebler/gateio-api/blob/master/docs/images/logoDarkMode2.svg?raw=true#gh-dark-mode-only">
+      <img alt="SDK Logo" src="https://github.com/tiagosiebler/gateio-api/blob/master/docs/images/logoBrightMode2.svg?raw=true#gh-light-mode-only">
+    </picture>
+  </a>
+</p>
+
+[![npm version](https://img.shields.io/npm/v/gateio-api)][1]
+[![npm size](https://img.shields.io/bundlephobia/min/gateio-api/latest)][1]
+[![npm downloads](https://img.shields.io/npm/dt/gateio-api)][1]
+[![Build & Test](https://github.com/tiagosiebler/gateio-api/actions/workflows/e2etest.yml/badge.svg?branch=master)](https://github.com/tiagosiebler/gateio-api/actions/workflows/e2etest.yml)
+[![last commit](https://img.shields.io/github/last-commit/tiagosiebler/gateio-api)][1]
+[![Telegram](https://img.shields.io/badge/chat-on%20telegram-blue.svg)](https://t.me/nodetraders)
+
+[1]: https://www.npmjs.com/package/gateio-api
+
+Updated & performant JavaScript & Node.js SDK for the Gate.com (gate.io) REST APIs and WebSockets:
+
+- Professional, robust & performant Gate.com SDK with extensive production use in live trading environments.
+- Extensive integration with Gate.com (Gate.io) REST APIs and WebSockets.
+- Complete TypeScript support (with type declarations for most API requests & responses).
+  - Strongly typed requests and responses.
+  - Automated end-to-end tests ensuring reliability.
+- Actively maintained with a modern, promise-driven interface.
+- Gate.com REST APIs for Gate.com Spot, Margin, Perpetual Futures, Delivery Futures, Options & Announcements APIs.
+  - Unified RestClient for all Gate.com trading products.
+  - Strongly typed on most requests and responses.
+- Support for seamless API authentication for private Gate.com REST API and WebSocket calls.
+- Robust WebSocket integration with configurable connection heartbeats & automatic reconnect then resubscribe workflows.
+  - Event driven messaging.
+  - Smart websocket persistence with automatic reconnection handling.
+    - Automatically handle silent websocket disconnections through timed heartbeats, including the scheduled 24hr disconnect.
+    - Automatically handle listenKey persistence and expiration/refresh.
+    - Emit `reconnected` event when dropped connection is restored.
+  - Support for Gate.com Spot, Margin, Perpetual Futures, Delivery Futures & Options.
+- WebSocket API for Gate.com Spot, Margin, Perpetual Futures & Delivery Futures.
+  - Automatic connectivity via existing WebsocketClient, just call sendWSAPIRequest to trigger a request.
+  - Automatic authentication, just call sendWSAPIRequest with channel & parameters.
+  - Choose between two interfaces for WS API communication:
+    - Event-driven interface, fire & forget via sendWSAPIRequest and receive async replies via wsClient's event emitter.
+    - Promise-driven interface, simply use the WebsocketAPIClient for a REST-like experience. Use the WebSocket API like a REST API! See [examples/ws-api-client.ts](./examples/ws-api-client.ts) for a demonstration.
+- Heavy automated end-to-end testing with real API calls.
+- Proxy support via axios integration.
+- Active community support & collaboration in telegram: [Node.js Algo Traders](https://t.me/nodetraders).
+
+## Table of Contents
+
+- [Installation](#installation)
+- [Examples](#examples)
+- [Issues & Discussion](#issues--discussion)
+- [Related Projects](#related-projects)
+- [Documentation](#documentation)
+- [Structure](#structure)
+- [Usage](#usage)
+  - [REST API Client](#rest-api)
+  - [WebSocket Client](#websockets)
+    - [WebSocket Data Streams](#websocket-data-streams)
+    - [WebSocket API](#websocket-api)
+      - [Event Driven API](#event-driven-api)
+      - [REST-like API](#rest-like-api)
+- [Customise Logging](#customise-logging)
+- [LLMs & AI](#use-with-llms--ai)
+- [Used By](#used-by)
+- [Contributions & Thanks](#contributions--thanks)
+
+## Installation
+
+`npm install --save gateio-api`
+
+## Examples
+
+Refer to the [examples](./examples) folder for implementation demos, including:
+
+- **REST API Examples**: spot trading, futures trading, account management
+- **WebSocket Examples**: public market data streams, private account data, WebSocket API usage
+- **Spot Trading**: comprehensive spot market examples
+- **Futures Trading**: perpetual and delivery futures examples
+- **WebSocket API**: both event-driven and promise-driven approaches
+
+## Issues & Discussion
+
+- Issues? Check the [issues tab](https://github.com/tiagosiebler/gateio-api/issues).
+- Discuss & collaborate with other node devs? Join our [Node.js Algo Traders](https://t.me/nodetraders) engineering community on telegram.
+- Follow our announcement channel for real-time updates on [X/Twitter](https://x.com/sieblyio)
+
+<!-- template_related_projects -->
+
+## Related projects
+
+Check out my related JavaScript/TypeScript/Node.js projects:
+
+- Try my REST API & WebSocket SDKs:
+  - [Bybit-api Node.js SDK](https://www.npmjs.com/package/bybit-api)
+  - [Okx-api Node.js SDK](https://www.npmjs.com/package/okx-api)
+  - [Binance Node.js SDK](https://www.npmjs.com/package/binance)
+  - [Gateio-api Node.js SDK](https://www.npmjs.com/package/gateio-api)
+  - [Bitget-api Node.js SDK](https://www.npmjs.com/package/bitget-api)
+  - [Kucoin-api Node.js SDK](https://www.npmjs.com/package/kucoin-api)
+  - [Coinbase-api Node.js SDK](https://www.npmjs.com/package/coinbase-api)
+  - [Bitmart-api Node.js SDK](https://www.npmjs.com/package/bitmart-api)
+- Try my misc utilities:
+  - [OrderBooks Node.js](https://www.npmjs.com/package/orderbooks)
+  - [Crypto Exchange Account State Cache](https://www.npmjs.com/package/accountstate)
+- Check out my examples:
+  - [awesome-crypto-examples Node.js](https://github.com/tiagosiebler/awesome-crypto-examples)
+  <!-- template_related_projects_end -->
+
+## Documentation
+
+Most methods accept JS objects. These can be populated using parameters specified by Gate.com's API documentation, or check the type definition in each class within this repository.
+
+### API Documentation Links
+
+- [Gate.com/gate.io API Documentation](https://www.gate.com/docs/developers/apiv4/en/)
+  - [Spot Trading API](https://www.gate.com/docs/developers/apiv4/en/#spot-new)
+  - [Margin Trading API](https://www.gate.com/docs/developers/apiv4/en/#margin-new)
+  - [Futures Trading API](https://www.gate.com/docs/developers/apiv4/en/#futures-new)
+  - [Options Trading API](https://www.gate.com/docs/developers/apiv4/en/#options-new)
+  - [WebSocket API](https://www.gate.com/docs/developers/apiv4/en/#websocket-api)
+- [REST Endpoint Function List](./docs/endpointFunctionList.md)
+- [TSDoc Documentation (autogenerated using typedoc)](https://tsdocs.dev/docs/gateio-api)
+
+## Structure
+
+This project uses typescript. Resources are stored in 2 key structures:
+
+- [src](./src) - the whole connector written in typescript
+- [examples](./examples) - some implementation examples & demonstrations. Contributions are welcome!
+
+---
+
+# Usage
+
+Create API credentials on Gate.com's website:
+
+- [Gate.com API Key Management](https://www.gate.com/myaccount/api_key_manage)
+
+## REST API
+
+The SDK provides a unified `RestClient` for all Gate.com trading products including Spot, Margin, Perpetual Futures, Delivery Futures, and Options. This single client handles all REST API operations across all trading markets.
+
+To use any of Gate.com's REST APIs in JavaScript/TypeScript/Node.js, import (or require) the `RestClient`:
+
+```javascript
+const { RestClient } = require('gateio-api');
+
+const API_KEY = 'xxx';
+const PRIVATE_KEY = 'yyy';
+
+const client = new RestClient({
+  apiKey: API_KEY,
+  apiSecret: PRIVATE_KEY,
+});
+
+client
+  .getSpotTicker()
+  .then((result) => {
+    console.log('all spot tickers result: ', result);
+  })
+  .catch((err) => {
+    console.error('spot ticker error: ', err);
+  });
+
+client
+  .getSpotOrders({
+    currency_pair: 'BTC_USDT', // Specify the currency pair
+    status: 'open', // Specify the status of the orders to fetch
+  })
+  .then((result) => {
+    console.log('getSpotOrders result: ', result);
+  })
+  .catch((err) => {
+    console.error('getSpotOrders error: ', err);
+  });
+```
+
+See [RestClient](./src/RestClient.ts) for further information, or the [examples](./examples/) for lots of usage examples.
+
+## WebSockets
+
+All WebSocket functionality is supported via the unified `WebsocketClient`. This client handles all Gate.com WebSocket streams with automatic connection management and reconnection.
+
+Key WebSocket features:
+
+- Event driven messaging
+- Smart WebSocket persistence with automatic reconnection
+- Heartbeat mechanisms to detect disconnections
+- Automatic resubscription after reconnection
+- Support for all Gate.com trading products (Spot, Margin, Futures, Options)
+- WebSocket API support for real-time trading operations
+
+### WebSocket Data Streams
+
+All available WebSockets can be used via a shared `WebsocketClient`. The WebSocket client will automatically open/track/manage connections as needed. Each unique connection (one per server URL) is tracked using a WsKey (each WsKey is a string - see [WS_KEY_MAP](src/lib/websocket/websocket-util.ts) for a list of supported values).
+
+Any subscribe/unsubscribe events will need to include a WsKey, so the WebSocket client understands which connection the event should be routed to. See examples below or in the [examples](./examples/) folder on GitHub.
+
+Data events are emitted from the WebsocketClient via the `update` event, see example below:
+
+```javascript
+const { WebsocketClient } = require('gateio-api');
+
+const API_KEY = 'xxx';
+const PRIVATE_KEY = 'yyy';
+
+const wsConfig = {
+  apiKey: API_KEY,
+  apiSecret: PRIVATE_KEY,
+
+  /*
+    The following parameters are optional:
+  */
+
+  // Livenet is used by default, use this to enable testnet:
+  // useTestnet: true
+
+  // how long to wait (in ms) before deciding the connection should be terminated & reconnected
+  // pongTimeout: 1000,
+
+  // how often to check (in ms) that WS connection is still alive
+  // pingInterval: 10000,
+
+  // how long to wait before attempting to reconnect (in ms) after connection is closed
+  // reconnectTimeout: 500,
+
+  // config options sent to RestClient (used for time sync). See RestClient docs.
+  // restOptions: { },
+
+  // config for axios used for HTTP requests. E.g for proxy support
+  // requestOptions: { }
+};
+
+const ws = new WebsocketClient(wsConfig);
+
+/**
+ * Subscribing to data:
+ **/
+
+const userOrders = {
+  topic: 'spot.orders',
+  payload: ['BTC_USDT', 'ETH_USDT', 'MATIC_USDT'],
+};
+
+const userTrades = {
+  topic: 'spot.usertrades',
+  payload: ['BTC_USDT', 'ETH_USDT', 'MATIC_USDT'],
+};
+
+const userPriceOrders = {
+  topic: 'spot.priceorders',
+  payload: ['!all'],
+};
+
+// subscribe to multiple topics at once
+ws.subscribe([userOrders, userTrades, userPriceOrders], 'spotV4');
+
+// and/or subscribe to individual topics on demand
+ws.subscribe(
+  {
+    topic: 'spot.priceorders',
+    payload: ['!all'],
+  },
+  'spotV4',
+);
+
+// Some topics don't need params, for those you can just subscribe with a string (or use a topic + payload object as above)
+ws.subscribe('spot.balances', 'spotV4');
+
+/**
+ * Handling events:
+ **/
+
+// Listen to events coming from websockets. This is the primary data source
+ws.on('update', (data) => {
+  console.log('data', data);
+});
+
+// Optional: Listen to websocket connection open event (automatic after subscribing to one or more topics)
+ws.on('open', ({ wsKey, event }) => {
+  console.log('connection open for websocket with ID: ' + wsKey);
+});
+
+// Optional: Listen to responses to websocket queries (e.g. the reply after subscribing to a topic)
+ws.on('response', (response) => {
+  console.log('response', response);
+});
+
+// Optional: Listen to connection close event. Unexpected connection closes are automatically reconnected.
+ws.on('close', () => {
+  console.log('connection closed');
+});
+
+// Optional: listen to internal exceptions. Useful for debugging if something weird happens
+ws.on('exception', (data) => {
+  console.error('exception: ', data);
+});
+
+// Optional: Listen to raw error events.
+ws.on('error', (err) => {
+  console.error('ERR', err);
+});
+```
+
+See [WebsocketClient](./src/WebsocketClient.ts) for further information and make sure to check the [examples](./examples/) folder for much more detail.
+
+### Websocket API
+
+Gate.com supports sending requests (commands) over an active WebSocket connection. This is called the WebSocket API.
+
+The WebSocket API is available through two approaches, depending on individual preference:
+
+#### Event Driven API
+
+The WebSocket API is available in the [WebsocketClient](./src/WebsocketClient.ts) via the `sendWSAPIRequest(wsKey, channel, params)` method.
+
+Each call to this method is wrapped in a promise, which you can async await for a response, or handle it in a raw event-driven design.
+
+- event-driven:
+  - send requests via `client.sendWSAPIRequest(wsKey, channel, params).catch(e => console.error('WS API exception for channel', channel, e))`, fire and forget, don't use await
+  - handle async replies via event handlers on `client.on('exception', cb)` and `client.on('response', cb)`
+- promise-driven:
+  - send requests via `const result = await client.sendWSAPIRequest(wsKey, channel, params)`, which returns a promise
+  - await each call
+  - use try/catch blocks to handle promise rejections
+
+#### REST-like API
+
+The WebSocket API is also available in a promise-wrapped REST-like format. Either, as above, await any calls to `sendWSAPIRequest(...)`, or directly use the convenient WebsocketAPIClient. This class is very similar to existing REST API classes (such as the RestClient).
+
+It provides one function per endpoint, feels like a REST API and will automatically route your request via an automatically persisted, authenticated and health-checked WebSocket API connection.
+
+Below is an example showing how easy it is to use the WebSocket API without any concern for the complexity of managing WebSockets.
+
+```javascript
+const { WebsocketAPIClient } = require('gateio-api');
+
+const API_KEY = 'xxx';
+const API_SECRET = 'yyy';
+
+async function start() {
+  // Make an instance of the WS API Client
+  const wsClient = new WebsocketAPIClient({
+    apiKey: API_KEY,
+    apiSecret: API_SECRET,
+    // Automatically re-auth WS API, if we were auth'd before and get reconnected
+    reauthWSAPIOnReconnect: true,
+  });
+
+  try {
+    // Connection will authenticate automatically before first request
+    // Make WebSocket API calls, very similar to a REST API:
+
+    /* ============ SPOT TRADING EXAMPLES ============ */
+
+    // Submit a new spot order
+    const newOrder = await wsClient.submitNewSpotOrder({
+      text: 't-my-custom-id',
+      currency_pair: 'BTC_USDT',
+      type: 'limit',
+      account: 'spot',
+      side: 'buy',
+      amount: '1',
+      price: '10000',
+    });
+    console.log('Order result:', newOrder.data);
+
+    // Cancel a spot order
+    const cancelOrder = await wsClient.cancelSpotOrder({
+      order_id: '1700664330',
+      currency_pair: 'BTC_USDT',
+      account: 'spot',
+    });
+    console.log('Cancel result:', cancelOrder.data);
+
+    // Get spot order status
+    const orderStatus = await wsClient.getSpotOrderStatus({
+      order_id: '1700664330',
+      currency_pair: 'BTC_USDT',
+      account: 'spot',
+    });
+    console.log('Order status:', orderStatus.data);
+
+    /* ============ FUTURES TRADING EXAMPLES ============ */
+
+    // Submit a new futures order
+    const newFuturesOrder = await wsClient.submitNewFuturesOrder({
+      contract: 'BTC_USDT',
+      size: 10,
+      price: '31503.28',
+      tif: 'gtc',
+      text: 't-my-custom-id',
+    });
+    console.log('Futures order result:', newFuturesOrder.data);
+
+    // Cancel a futures order
+    const cancelFuturesOrder = await wsClient.cancelFuturesOrder({
+      order_id: '74046514',
+    });
+    console.log('Cancel futures order result:', cancelFuturesOrder.data);
+
+    // Get futures order status
+    const futuresOrderStatus = await wsClient.getFuturesOrderStatus({
+      order_id: '74046543',
+    });
+    console.log('Futures order status:', futuresOrderStatus.data);
+  } catch (e) {
+    console.error('WS API Error:', e);
+  }
+}
+
+start();
+```
+
+For more detailed examples using any approach, refer to the [examples](./examples/) folder (e.g. [ws-api-client.ts](./examples/ws-api-client.ts)).
+
+---
+
+## Customise Logging
+
+Pass a custom logger which supports the log methods `silly`, `debug`, `notice`, `info`, `warning` and `error`, or override methods from the default logger as desired.
+
+```javascript
+const { WebsocketClient, DefaultLogger } = require('gateio-api');
+
+// Disable all logging on the silly level
+DefaultLogger.silly = () => {};
+
+const ws = new WebsocketClient({ key: 'xxx', secret: 'yyy' }, DefaultLogger);
+```
+
+## Use with LLMs & AI
+
+This SDK includes a bundled `llms.txt` file in the root of the repository. If you're developing with LLMs, use the included `llms.txt` with your LLM - it will significantly improve the LLMs understanding of how to correctly use this SDK.
+
+This file contains AI optimised structure of all the functions in this package, and their parameters for easier use with any learning models or artificial intelligence.
+
+---
+
+## Used By
+
+[![Repository Users Preview Image](https://dependents.info/tiagosiebler/gateio-api/image)](https://github.com/tiagosiebler/gateio-api/network/dependents)
+
+---
+
+<!-- template_contributions -->
+
+### Contributions & Thanks
+
+Have my projects helped you? Share the love, there are many ways you can show your thanks:
+
+- Star & share my projects.
+- Are my projects useful? Sponsor me on Github and support my effort to maintain & improve them: https://github.com/sponsors/tiagosiebler
+- Have an interesting project? Get in touch & invite me to it.
+- Or buy me all the coffee:
+  - ETH(ERC20): `0xA3Bda8BecaB4DCdA539Dc16F9C54a592553Be06C` <!-- metamask -->
+
+<!---
+old ones:
+  - BTC: `1C6GWZL1XW3jrjpPTS863XtZiXL1aTK7Jk`
+  - BTC(SegWit): `bc1ql64wr9z3khp2gy7dqlmqw7cp6h0lcusz0zjtls`
+  - ETH(ERC20): `0xe0bbbc805e0e83341fadc210d6202f4022e50992`
+  - USDT(TRC20): `TA18VUywcNEM9ahh3TTWF3sFpt9rkLnnQa
+-->
+<!-- template_contributions_end -->
+
+### Contributions & Pull Requests
+
+Contributions are encouraged, I will review any incoming pull requests. See the issues tab for todo items.
+
+<!-- template_star_history -->
+
+## Star History
+
+[![Star History Chart](https://api.star-history.com/svg?repos=tiagosiebler/bybit-api,tiagosiebler/okx-api,tiagosiebler/binance,tiagosiebler/bitget-api,tiagosiebler/bitmart-api,tiagosiebler/gateio-api,tiagosiebler/kucoin-api,tiagosiebler/coinbase-api,tiagosiebler/orderbooks,tiagosiebler/accountstate,tiagosiebler/awesome-crypto-examples&type=Date)](https://star-history.com/#tiagosiebler/bybit-api&tiagosiebler/okx-api&tiagosiebler/binance&tiagosiebler/bitget-api&tiagosiebler/bitmart-api&tiagosiebler/gateio-api&tiagosiebler/kucoin-api&tiagosiebler/coinbase-api&tiagosiebler/orderbooks&tiagosiebler/accountstate&tiagosiebler/awesome-crypto-examples&Date)
+
+<!-- template_star_history_end -->
+
+================
+File: tea.yaml
+================
+---
+version: 1.0.0
+codeOwners:
+  - '0xeb1a7BF44a801e33a339705A266Afc0Cba3D6D54'
+quorum: 1
+
+================
+File: tsconfig.cjs.json
+================
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "outDir": "dist/cjs",
+    "target": "esnext"
+  },
+  "include": ["src/**/*.*"]
+}
+
+================
+File: tsconfig.esm.json
+================
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "esnext",
+    "outDir": "dist/mjs",
+    "target": "esnext"
+  },
+  "include": ["src/**/*.*"]
+}
+
+================
+File: tsconfig.json
+================
+{
+  "compilerOptions": {
+    "allowSyntheticDefaultImports": true,
+    "baseUrl": ".",
+    "noEmitOnError": true,
+    "declaration": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": false,
+    "inlineSourceMap": false,
+    "lib": ["esnext"],
+    "listEmittedFiles": false,
+    "listFiles": false,
+    "moduleResolution": "node",
+    "noFallthroughCasesInSwitch": true,
+    "noImplicitAny": true,
+    "noUnusedParameters": true,
+    "pretty": true,
+    "removeComments": false,
+    "resolveJsonModule": true,
+    "skipLibCheck": false,
+    "sourceMap": true,
+    "strict": true,
+    "strictNullChecks": true,
+    "types": ["node", "jest"],
+    "module": "commonjs",
+    "outDir": "dist/cjs",
+    "target": "esnext"
+  },
+  "compileOnSave": true,
+  "exclude": ["node_modules", "dist"],
+  "include": ["src/**/*.*", "test/**/*.*", ".eslintrc.cjs"]
+}
+
+================
+File: tsconfig.linting.json
+================
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "outDir": "dist/cjs",
+    "target": "esnext",
+    "rootDir": "../",
+    "allowJs": true
+  },
+  "include": [
+    "src/**/*.*",
+    "test/**/*.*",
+    "examples/**/*.*",
+    ".eslintrc.cjs",
+    "jest.config.ts"
+  ]
 }
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gateio-api",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "gateio-api",
-      "version": "1.3.1",
+      "version": "1.3.2",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.12.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gateio-api",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "description": "Complete & Robust Node.js SDK for Gate.com's REST APIs, WebSockets & WebSocket APIs, with TypeScript declarations.",
   "scripts": {
     "clean": "rm -rf dist/*",

--- a/src/types/request/futures.ts
+++ b/src/types/request/futures.ts
@@ -198,7 +198,7 @@ export interface SubmitFuturesTriggeredOrderReq {
   initial: {
     contract: string;
     size?: number;
-    price?: string;
+    price: string; // Required: Order price. Set to 0 to use market price
     close?: boolean;
     tif?: 'gtc' | 'ioc';
     text?: string;
@@ -208,8 +208,8 @@ export interface SubmitFuturesTriggeredOrderReq {
   trigger: {
     strategy_type?: 0 | 1;
     price_type?: 0 | 1 | 2;
-    price?: string;
-    rule?: 1 | 2;
+    price: string; // Required: Price value for price trigger
+    rule: 1 | 2; // Required: Price Condition Type (1: >=, 2: <=)
     expiration?: number;
   };
   order_type?:
@@ -255,4 +255,15 @@ export interface GetFuturesPositionCloseHistoryReq {
 export interface GetFuturesInsuranceReq {
   settle: 'btc' | 'usdt' | 'usd';
   limit?: number;
+}
+
+export interface UpdateFuturesPriceTriggeredOrderReq {
+  settle: 'btc' | 'usdt' | 'usd';
+  order_id: string;
+  contract?: string;
+  size?: number;
+  price?: string;
+  trigger_price?: string;
+  price_type?: 0 | 1 | 2; // 0 - Latest trade price, 1 - Mark price, 2 - Index price
+  auto_size?: string; // Not required in single position mode
 }

--- a/src/types/response/account.ts
+++ b/src/types/response/account.ts
@@ -34,3 +34,20 @@ export interface StpGroupUser {
   stp_id: number;
   create_time: number;
 }
+
+export interface AccountMainKey {
+  state: number; // 1 - Normal, 2 - Locked, 3 - Frozen
+  mode: number; // 1 - Classic, 2 - Legacy Unified
+  name: string;
+  currency_pairs: string[];
+  user_id: number;
+  ip_whitelist: string[];
+  perms: {
+    name: string;
+    read_only: boolean;
+  }[];
+  key: string;
+  created_at: string;
+  updated_at: string;
+  last_access: string;
+}

--- a/src/types/response/wallet.ts
+++ b/src/types/response/wallet.ts
@@ -9,6 +9,26 @@ export interface CurrencyChain {
   decimal: string;
 }
 
+export interface DepositRecord {
+  id: string;
+  txid: string;
+  timestamp: string;
+  amount: string;
+  currency: string;
+  address: string;
+  memo?: string;
+  status:
+    | 'BLOCKED' // Deposit Blocked
+    | 'DEP_CREDITED' // Deposit Credited, Withdrawal Pending Unlock
+    | 'DONE' // Funds Credited to Spot Account
+    | 'INVALID' // Invalid Transaction
+    | 'MANUAL' // Manual Review Required
+    | 'PEND' // Processing
+    | 'REVIEW' // Under Compliance Review
+    | 'TRACK'; // Tracking Block Confirmations, Pending Spot Account Credit
+  chain: string;
+}
+
 export interface CreateDepositAddressResp {
   currency: string;
   address: string;

--- a/src/types/response/withdrawal.ts
+++ b/src/types/response/withdrawal.ts
@@ -9,18 +9,23 @@ export interface WithdrawalRecord {
   address: string;
   memo?: string;
   status:
-    | 'DONE'
-    | 'CANCEL'
-    | 'REQUEST'
-    | 'MANUAL'
-    | 'BCODE'
-    | 'EXTPEND'
-    | 'FAIL'
-    | 'INVALID'
-    | 'VERIFY'
-    | 'PROCES'
-    | 'PEND'
-    | 'DMOVE'
-    | 'SPLITPEND';
+    | 'BCODE' // Deposit Code Operation
+    | 'CANCEL' // Cancelled
+    | 'CANCELPEND' // Withdrawal Cancellation Pending
+    | 'DMOVE' // Pending Manual Review
+    | 'DONE' // Completed (Only considered truly on-chain when block_number > 0)
+    | 'EXTPEND' // Sent and Waiting for Confirmation
+    | 'FAIL' // On-Chain Failure Pending Confirmation
+    | 'FVERIFY' // Facial Verification in Progress
+    | 'INVALID' // Invalid Transaction
+    | 'LOCKED' // Wallet-Side Order Locked
+    | 'MANUAL' // Pending Manual Review
+    | 'PEND' // Processing
+    | 'PROCES' // Processing
+    | 'REJECT' // Rejected
+    | 'REQUEST' // Request in Progress
+    | 'REVIEW' // Under Review
+    | 'SPLITPEND' // Split Pending
+    | 'VERIFY'; // Verification in Progress
   chain: string;
 }


### PR DESCRIPTION
# Gate.io API SDK Update - Changelog v4.105.10 to v4.105.28

## 🆕 New Endpoints

### 1. Update Futures Price-Triggered Order
- **Method**: `updateFuturesPriceTriggeredOrder()`
- **Endpoint**: `PUT /futures/{settle}/price_orders/{order_id}`
- **Description**: Update a single price-triggered order

### 2. Get Account Main Keys
- **Method**: `getAccountMainKeys()`
- **Endpoint**: `GET /account/main_keys`
- **Description**: Query all main account API key information

## 📝 Type Updates

### New Types Added
- `AccountMainKey` - Response interface for main account API keys
- `DepositRecord` - Dedicated interface for deposit records with new status values
- `UpdateFuturesPriceTriggeredOrderReq` - Request parameters for updating price-triggered orders

### Updated Types
- `WithdrawalRecord` - Enhanced status field descriptions with detailed comments
- `SubmitFuturesTriggeredOrderReq` - Made `price` and `rule` fields **required** in trigger object
- `DepositRecord` - New status values: `BLOCKED`, `DEP_CREDITED` (removed `FINAL`)
- `CurrencyChain` - Documented `is_deposit_disabled` field

## 🔄 Method Updates

### Return Type Changes
- `getDepositRecords()` - Now returns `DepositRecord[]` instead of `WithdrawalRecord[]`

### Documentation Updates
- `cancelWithdrawal()` - Documented `block_number` field in response
- `getCurrencyChains()` - Added note about low liquidity currencies
- `getWithdrawalStatus()` - Added note about API limitations for low liquidity tokens
- `getSpotCurrencyPairs()` / `getSpotCurrencyPair()` - Marked `fee` field as deprecated
- `submitFuturesPriceTriggeredOrder()` - Documented required fields
- `submitEth2Swap()` - Updated terminology (ETH2 → GTETH)
- `getEth2RateHistory()` - Updated terminology (ETH2 → GTETH)
- `getUnifiedAccountInfo()` - Updated field descriptions for `cross_balance` and `iso_balance`

## ✅ Changes Summary

- ✅ 2 new endpoints implemented
- ✅ 3 new TypeScript interfaces added
- ✅ 4 existing interfaces updated
- ✅ 11 methods updated with improved documentation
- ✅ All imports and exports properly configured
- ✅ Zero linter errors
- ✅ Full TypeScript type safety maintained

## 📋 Breaking Changes

### Required Field Updates
- `SubmitFuturesTriggeredOrderReq.trigger.price` - Now **required** (was optional)
- `SubmitFuturesTriggeredOrderReq.trigger.rule` - Now **required** (was optional)
- `SubmitFuturesTriggeredOrderReq.initial.price` - Now **required** (was optional)

### Return Type Changes
- `getDepositRecords()` return type changed from `WithdrawalRecord[]` to `DepositRecord[]`

## 🔗 Related Changelog Versions

- v4.105.28 - Withdrawal block_number field, unified account field updates
- v4.105.27 - Status field description improvements
- v4.105.24 - Low liquidity currency documentation
- v4.105.20 - Deposit record enhancements
- v4.105.19 - ETH2 to GTETH terminology updates
- v4.105.18 - New update price-triggered order endpoint
- v4.105.11 - Main account keys endpoint, fee field deprecation
- v4.105.10 - Required fields in futures price-triggered orders

