### PR TITLE
fix(#99): omit url suffix when query params are empty

### DIFF
--- a/src/lib/BaseRestClient.ts
+++ b/src/lib/BaseRestClient.ts
@@ -540,8 +540,11 @@ export abstract class BaseRestClient {
       Timestamp: signResult.timestamp,
     };
 
-    const urlWithQueryParams =
-      options.url + '?' + signResult.queryParamsWithSign;
+    const urlSuffix = signResult.queryParamsWithSign
+      ? '?' + signResult.queryParamsWithSign
+      : '';
+
+    const urlWithQueryParams = options.url + urlSuffix;
 
     if (method === 'GET' || !params?.body) {
       return {


### PR DESCRIPTION
## Summary
- Some requests have parameters as part of the endpoint, not query parameters. This empty-query-params scenario left a trailing `?` in the URL. Fixed the behaviour to only do so if query parameters are in the request. Fixes #99 
<!-- Add a brief description of the pr: -->

## Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->

## PR Checklist

As part of the PR, make sure you have:
- [ ] No breaking changes / documented all breaking changes clearly.
- [ ] Updated & checked that all tests pass.
- [ ] Increased the version number in the package.json <!-- Only if your changes need to be published to npm -->
- [ ] Checked `npm install` runs without issue.
- [ ] Included the package-lock.json, if it changed after npm install <!-- The version number should update, if you also updated the package.json version number -->
- [ ] Checked `npm run build` runs without issue.
- [ ] Updated the endpoint map (optional, if you know how).
- [ ] Run llms.txt generator (optional, if you know how).
