### PR TITLE
fix(v1.5.1): use POST for closeCrossExPosition

### DIFF
--- a/docs/endpointFunctionList.md
+++ b/docs/endpointFunctionList.md
@@ -387,7 +387,7 @@ This table includes all endpoints from the official Exchange API docs and corres
 | [getCrossExPositionLeverage()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L5361) | :closed_lock_with_key:  | GET | `/crossex/positions/leverage` |
 | [setCrossExMarginPositionLeverage()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L5375) | :closed_lock_with_key:  | POST | `/crossex/margin_positions/leverage` |
 | [getCrossExMarginPositionLeverage()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L5391) | :closed_lock_with_key:  | GET | `/crossex/margin_positions/leverage` |
-| [closeCrossExPosition()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L5405) | :closed_lock_with_key:  | DELETE | `/crossex/position` |
+| [closeCrossExPosition()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L5405) | :closed_lock_with_key:  | POST | `/crossex/position` |
 | [getCrossExInterestRate()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L5419) | :closed_lock_with_key:  | GET | `/crossex/interest_rate` |
 | [getCrossExFeeRate()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L5432) | :closed_lock_with_key:  | GET | `/crossex/fee` |
 | [getCrossExPositions()](https://github.com/tiagosiebler/gateio-api/blob/master/src/RestClient.ts#L5444) | :closed_lock_with_key:  | GET | `/crossex/positions` |

--- a/examples/apidoc/RestClient/closeCrossExPosition.js
+++ b/examples/apidoc/RestClient/closeCrossExPosition.js
@@ -3,7 +3,7 @@ const { RestClient } = require('gateio-api');
   // This example shows how to call this Gate.io API endpoint with either node.js, javascript (js) or typescript (ts) with the npm module "gateio-api" for Gate.io exchange
   // This Gate.io API SDK is available on npm via "npm install gateio-api"
   // ENDPOINT: /crossex/position
-  // METHOD: DELETE
+  // METHOD: POST
   // PUBLIC: NO
 
 const client = new RestClient({

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gateio-api",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "description": "Complete & Robust Node.js SDK for Gate.com's REST APIs, WebSockets & WebSocket APIs, with TypeScript declarations.",
   "scripts": {
     "clean": "rm -rf dist/*",

--- a/src/RestClient.ts
+++ b/src/RestClient.ts
@@ -5405,7 +5405,7 @@ export class RestClient extends BaseRestClient {
   closeCrossExPosition(
     params: CloseCrossExPositionReq,
   ): Promise<CloseCrossExPositionResp> {
-    return this.deletePrivate('/crossex/position', { body: params });
+    return this.postPrivate('/crossex/position', { body: params });
   }
 
   /**


### PR DESCRIPTION
<img width="2486" height="1486" alt="image" src="https://github.com/user-attachments/assets/1f565a5a-6a4d-4071-82f6-7dc66b591565" />

## Summary
- Fix `closeCrossExPosition` to use `POST /crossex/position` instead of `DELETE`.
- Update the related API example and endpoint map to keep the documented HTTP method in sync.
- Bump `package.json` version from `1.5.0` to `1.5.1`.

## Additional Information
- This change is intended as a bug fix for the Cross Exchange position close request method.
- No breaking API changes are expected from the SDK surface itself.
- `package-lock.json` was intentionally not updated.

## PR Checklist

As part of the PR, make sure you have:
- [x] No breaking changes / documented all breaking changes clearly.
- [ ] Updated & checked that all tests pass.
- [ ] Increased the version number in the package.json <!-- Only if your changes need to be published to npm -->
- [ ] Checked `npm install` runs without issue.
- [ ] Included the package-lock.json, if it changed after npm install <!-- The version number should update, if you also updated the package.json version number -->
- [ ] Checked `npm run build` runs without issue.
- [x] Updated the endpoint map (optional, if you know how).
- [ ] Run llms.txt generator (optional, if you know how).
