### PR TITLE
chore(v1.5.4): Move optionalDependencies to devDependencies and update README badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@
 [![Build & Test](https://github.com/tiagosiebler/gateio-api/actions/workflows/e2etest.yml/badge.svg?branch=master)](https://github.com/tiagosiebler/gateio-api/actions/workflows/e2etest.yml)
 [![last commit](https://img.shields.io/github/last-commit/tiagosiebler/gateio-api)][1]
 [![Telegram](https://img.shields.io/badge/chat-on%20telegram-blue.svg)](https://t.me/nodetraders)
+[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/tiagosiebler/gateio-api)
 
 [1]: https://www.npmjs.com/package/gateio-api
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gateio-api",
-  "version": "1.5.3",
+  "version": "1.5.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "gateio-api",
-      "version": "1.5.3",
+      "version": "1.5.4",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.13.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gateio-api",
-  "version": "1.5.3",
+  "version": "1.5.4",
   "description": "Complete & Robust Node.js SDK for Gate.com's REST APIs, WebSockets & WebSocket APIs, with TypeScript declarations.",
   "scripts": {
     "clean": "rm -rf dist/*",


### PR DESCRIPTION
## Summary
- Move webpack-related optionalDependencies into devDependencies where applicable
- Bump patch version when package.json dependencies changed
- Add Ask DeepWiki badge to README

## Test plan
- [ ] CI passes
- [ ] `npm i` succeeds locally